### PR TITLE
Immortal command: Confiscate

### DIFF
--- a/json/help/help.json
+++ b/json/help/help.json
@@ -722,6 +722,11 @@
       "keyword": "'ACID BREATH' 'FIRE BREATH' 'FROST BREATH' 'GAS BREATH' 'LIGHTNING BREATH'",
       "level": 0,
       "text": "Syntax: cast 'acid breath'      <victim>\nSyntax: cast 'fire breath'      <victim>\nSyntax: cast 'frost breath'     <victim>\nSyntax: cast 'gas breath'\nSyntax: cast 'lightning breath' <victim>\n\nThese spells are for the use of dragons.  Acid, fire, frost, and lightning\ndamage one victim, whereas gas damages every PC in the room.  Fire and\nfrost can break objects, and acid can damage armor.\n\nHigh level mages may learn and cast these spells as well.\n"
+    },
+    {
+      "keyword": "CONFISCATE",
+      "level": 58,
+      "text": "Syntax: confiscate <item> <player>\n\nConfiscate will take an item from a player and put it in the\nimmortal's inventory.  If the item is equipped on the player it\nwill be unequipped.\n\nThe player is given notice that this has occured.\n"
     }
   ]
 }}]

--- a/src/descs.c
+++ b/src/descs.c
@@ -97,7 +97,7 @@ int init_socket (int port) {
     sa.sin_family = AF_INET;
     sa.sin_port = htons (port);
     sa.sin_addr.s_addr = inet_addr( mud_ipaddress );
-    log_f("Set IP address to %s", mud_ipaddress);
+    log_f("Set IP address to %s on port %d", mud_ipaddress, port);
 
     if (bind (fd, (struct sockaddr *) &sa, sizeof (sa)) < 0) {
         perror ("Init socket: bind");

--- a/src/interp.c
+++ b/src/interp.c
@@ -309,6 +309,7 @@ const CMD_T cmd_table[] = {
     {"wizlock",     do_wizlock,     POS_DEAD,     L2, LOG_ALWAYS, 1},
 
     {"force",       do_force,       POS_DEAD,     L7, LOG_ALWAYS, 1},
+    {"confiscate",  do_confiscate,  POS_DEAD,     L7, LOG_ALWAYS, 1},
     {"load",        do_load,        POS_DEAD,     L4, LOG_ALWAYS, 1},
     {"newlock",     do_newlock,     POS_DEAD,     L4, LOG_ALWAYS, 1},
     {"nochannels",  do_nochannels,  POS_DEAD,     L5, LOG_ALWAYS, 1},

--- a/src/wiz_l7.c
+++ b/src/wiz_l7.c
@@ -33,6 +33,8 @@
 #include "rooms.h"
 #include "find.h"
 #include "globals.h"
+#include "chars.h"
+#include "objs.h"
 
 #include "wiz_l7.h"
 
@@ -123,4 +125,58 @@ DEFINE_DO_FUN (do_force) {
         interpret (victim, argument);
     }
     send_to_char ("Ok.\n\r", ch);
+}
+
+/*
+ * Confiscates an object from a player.  The command is useful for cases when
+ * an immortal needs to get a noremove or nodrop item from a player to do
+ * a restring or if they need to confiscate something for really any other
+ * reason.
+ *
+ * Code by Keridan of Benevolent Iniquity, additions and conversions for
+ * BaseMUD by Rhien (Blake Pell).
+ */
+DEFINE_DO_FUN (do_confiscate) {
+    CHAR_T *victim;
+    OBJ_T *obj;
+    char arg1[MAX_INPUT_LENGTH];
+    bool found = FALSE;
+
+    argument = one_argument(argument, arg1);
+
+    BAIL_IF (IS_NPC(ch),
+        "Mobiles can't use confiscate command.\r\n", ch);
+
+    BAIL_IF (IS_NULLSTR(argument) || IS_NULLSTR(arg1),
+        "Syntax: confiscate <item> <player>\r\n", ch);
+
+    BAIL_IF ((victim = find_char_world(ch, argument)) == NULL,
+        "They aren't here.\r\n", ch);
+
+    BAIL_IF (victim->level >= ch->level,
+        "They are too high level for you to do that.\r\n", ch);
+
+    // Go through the victim's objects and find the first object that matches.
+    for (obj = victim->carrying; obj != NULL; obj = obj->next_content)
+    {
+        if (is_name(arg1, obj->name))
+        {
+            found = TRUE;
+            break;
+        }
+    }
+
+    BAIL_IF (!found,
+        "They do not have that item.\r\n", ch);
+
+    // Take the item from the character and give it to the immortal.
+    obj_take_from_char(obj);
+    obj_give_to_char (obj, ch);
+
+    // For transparency both the immortal is notified what object was confiscated AND
+    // the player is notified that it happened.  In the future perhaps a silent option
+    // should be built in for cases where the immortal wants to confiscate something in a
+    // quest and not disrupt the ambiance of whatever roleplay is occuring.
+    printf_to_char(ch, "You have confiscated %s from %s.\r\n", obj->short_descr, victim->name);
+    printf_to_char(victim, "%s has confiscated %s from you.\r\n", PERS_AW(ch, victim), obj->short_descr);
 }

--- a/src/wiz_l7.h
+++ b/src/wiz_l7.h
@@ -35,5 +35,6 @@
 
 /* Commands. */
 DECLARE_DO_FUN (do_force);
+DECLARE_DO_FUN (do_confiscate);
 
 #endif


### PR DESCRIPTION
Confiscate is an immortal command that allows the immortal to take an item from a player or a mob regardless of any bits on the object.  If you were to use the force command to have a player give you an item it would fail in cases where the item is nodrop or noremove, they couldn't see it, etc.  The help file was added into the JSON as well for this command.

A typical use case would be, a player wants a restring but can't let go of the item in question to give to the immortal.  A lesser use case would be that an immortal needs to confiscate an item because of a bug, etc.

Additionally in this pull request is a change to log the port on startup.  I had something running on the muds startup port (even after I had changed it to a new port) and it wasn't apparent at first.  When the IP address is bound it will log the port now also alongside the IP.