### PR TITLE
refactor: replace send_to_char with printf_to_char

### DIFF
--- a/src/act_board.c
+++ b/src/act_board.c
@@ -67,7 +67,7 @@ void do_nread_next (CHAR_T *ch, char *argument, time_t *last_note) {
         sprintf (buf, "Changed to next board, %s.\n\r", ch->pcdata->board->name);
     else
         sprintf (buf, "There are no more boards.\n\r");
-    send_to_char (buf, ch);
+    printf_to_char (ch, buf);
 }
 
 void do_nread_number (CHAR_T *ch, char *argument, time_t *last_note,
@@ -142,7 +142,7 @@ DEFINE_DO_FUN (do_nwrite) {
             break;
         }
 
-        send_to_char (buf, ch);
+        printf_to_char (ch, buf);
         printf_to_char (ch, "\n\r{YTo{x:      ");
 
         ch->desc->connected = CON_NOTE_TO;
@@ -156,7 +156,7 @@ DEFINE_DO_FUN (do_nwrite) {
                        ctime_fixed (&ch->pcdata->in_progress->expire),
                        ch->pcdata->in_progress->subject);
         printf_to_char (ch, "{GYour note so far:{x\n\r");
-        send_to_char (ch->pcdata->in_progress->text, ch);
+        printf_to_char (ch, ch->pcdata->in_progress->text);
 
         send_to_char ("\n\rEnter text. Type {W~{x or {WEND{x on an empty line to end note.\n\r"
                           "=======================================================\n\r", ch);

--- a/src/act_board.c
+++ b/src/act_board.c
@@ -62,7 +62,7 @@ void do_nread_next (CHAR_T *ch, char *argument, time_t *last_note) {
         }
     }
 
-    send_to_char ("No new notes in this board.\n\r", ch);
+    printf_to_char (ch, "No new notes in this board.\n\r");
     if (char_change_to_next_board (ch))
         sprintf (buf, "Changed to next board, %s.\n\r", ch->pcdata->board->name);
     else
@@ -143,7 +143,7 @@ DEFINE_DO_FUN (do_nwrite) {
         }
 
         send_to_char (buf, ch);
-        send_to_char ("\n\r{YTo{x:      ", ch);
+        printf_to_char (ch, "\n\r{YTo{x:      ");
 
         ch->desc->connected = CON_NOTE_TO;
         /* nanny takes over from here */
@@ -155,7 +155,7 @@ DEFINE_DO_FUN (do_nwrite) {
                        ch->pcdata->in_progress->to_list,
                        ctime_fixed (&ch->pcdata->in_progress->expire),
                        ch->pcdata->in_progress->subject);
-        send_to_char ("{GYour note so far:{x\n\r", ch);
+        printf_to_char (ch, "{GYour note so far:{x\n\r");
         send_to_char (ch->pcdata->in_progress->text, ch);
 
         send_to_char ("\n\rEnter text. Type {W~{x or {WEND{x on an empty line to end note.\n\r"
@@ -195,7 +195,7 @@ DEFINE_DO_FUN (do_nremove) {
 
     note_unlink (p, ch->pcdata->board);
     note_free (p);
-    send_to_char ("Note removed!\n\r", ch);
+    printf_to_char (ch, "Note removed!\n\r");
     board_save (ch->pcdata->board);
 }
 
@@ -243,7 +243,7 @@ DEFINE_DO_FUN (do_ncatchup) {
         "Alas, there are no notes in that board.\n\r", ch);
 
     ch->pcdata->last_note[board_number(ch->pcdata->board)] = p->date_stamp;
-    send_to_char ("All mesages skipped.\n\r", ch);
+    printf_to_char (ch, "All mesages skipped.\n\r");
 }
 
 /* Show all accessible boards with their numbers of unread messages OR
@@ -276,11 +276,11 @@ DEFINE_DO_FUN (do_board) {
 
         /* Inform of rights */
         if (ch->pcdata->board->read_level > char_get_trust(ch))
-            send_to_char ("You cannot read nor write notes on this board.\n\r", ch);
+            printf_to_char (ch, "You cannot read nor write notes on this board.\n\r");
         else if (ch->pcdata->board->write_level > char_get_trust(ch))
-            send_to_char ("You can only read notes from this board.\n\r", ch);
+            printf_to_char (ch, "You can only read notes from this board.\n\r");
         else
-            send_to_char ("You can both read and write on this board.\n\r", ch);
+            printf_to_char (ch, "You can both read and write on this board.\n\r");
         return;
     }
 
@@ -305,7 +305,7 @@ DEFINE_DO_FUN (do_board) {
                 : "You can both read and write here");
         }
         else
-            send_to_char ("No such board.\n\r", ch);
+            printf_to_char (ch, "No such board.\n\r");
         return;
     }
 
@@ -345,9 +345,9 @@ DEFINE_DO_FUN (do_note) {
     else if (!str_cmp (arg, "remove"))
         do_nremove (ch, argument);
     else if (!str_cmp (arg, "purge"))
-        send_to_char ("Obsolete.\n\r", ch);
+        printf_to_char (ch, "Obsolete.\n\r");
     else if (!str_cmp (arg, "archive"))
-        send_to_char ("Obsolete.\n\r", ch);
+        printf_to_char (ch, "Obsolete.\n\r");
     else if (!str_cmp (arg, "catchup"))
         do_ncatchup (ch, argument);
     else

--- a/src/act_comm.c
+++ b/src/act_comm.c
@@ -198,17 +198,17 @@ DEFINE_DO_FUN (do_socials) {
     for (soc = social_get_first(); soc != NULL; soc = social_get_next (soc)) {
         printf_to_char (ch, "%-12s", soc->name);
         if (++col % 6 == 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
     }
     if (col % 6 != 0)
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
 }
 
 /* RT code to display channel status */
 DEFINE_DO_FUN (do_channels) {
     /* lists all channels and their status */
-    send_to_char ("   Channel        Status\n\r", ch);
-    send_to_char ("---------------------------\n\r", ch);
+    printf_to_char (ch, "   Channel        Status\n\r");
+    printf_to_char (ch, "---------------------------\n\r");
 
     do_autolist_flag ("{dgossip{x",     ch, ~ch->comm, COMM_NOGOSSIP);
     do_autolist_flag ("{aauction{x",    ch, ~ch->comm, COMM_NOAUCTION);
@@ -221,31 +221,31 @@ DEFINE_DO_FUN (do_channels) {
     if (IS_IMMORTAL (ch))
         do_autolist_flag ("{igod channel{x", ch, ~ch->comm, COMM_NOWIZ);
 
-    send_to_char ("---------------------------\n\r", ch);
+    printf_to_char (ch, "---------------------------\n\r");
     do_autolist_flag ("{tquiet mode{x", ch, ch->comm, COMM_QUIET);
     do_autolist_flag ("AFK", ch, ch->comm, COMM_AFK);
 
-    send_to_char ("---------------------------\n\r", ch);
+    printf_to_char (ch, "---------------------------\n\r");
     if (ch->lines != PAGELEN) {
         if (ch->lines) {
             printf_to_char (ch, "You display %d lines of scroll.\n\r",
                 ch->lines + 2);
         }
         else
-            send_to_char ("Scroll buffering is off.\n\r", ch);
+            printf_to_char (ch, "Scroll buffering is off.\n\r");
     }
 
     if (ch->prompt != NULL)
         printf_to_char (ch, "Your current prompt is: %s\n\r", ch->prompt);
 
     if (IS_SET (ch->comm, COMM_NOSHOUT))
-        send_to_char ("You cannot shout.\n\r", ch);
+        printf_to_char (ch, "You cannot shout.\n\r");
     if (IS_SET (ch->comm, COMM_NOTELL))
-        send_to_char ("You cannot use tell.\n\r", ch);
+        printf_to_char (ch, "You cannot use tell.\n\r");
     if (IS_SET (ch->comm, COMM_NOCHANNELS))
-        send_to_char ("You cannot use channels.\n\r", ch);
+        printf_to_char (ch, "You cannot use channels.\n\r");
     if (IS_SET (ch->comm, COMM_NOEMOTE))
-        send_to_char ("You cannot show emotions.\n\r", ch);
+        printf_to_char (ch, "You cannot show emotions.\n\r");
 }
 
 /* RT deaf blocks out all shouts */
@@ -574,10 +574,10 @@ DEFINE_DO_FUN (do_pose) {
 
 DEFINE_DO_FUN (do_bug) {
     append_file (ch, BUG_FILE, argument);
-    send_to_char ("Bug logged.\n\r", ch);
+    printf_to_char (ch, "Bug logged.\n\r");
 }
 
 DEFINE_DO_FUN (do_typo) {
     append_file (ch, TYPO_FILE, argument);
-    send_to_char ("Typo logged.\n\r", ch);
+    printf_to_char (ch, "Typo logged.\n\r");
 }

--- a/src/act_conf.c
+++ b/src/act_conf.c
@@ -52,7 +52,7 @@ void do_colour_one (CHAR_T *ch, const COLOUR_SETTING_T *setting,
     /* Is this the beginning of our menu? */
     if (buf[0] == '\0') {
         if (colour != NULL)
-            send_to_char ("The following colours have been set:\n\r", ch);
+            printf_to_char (ch, "The following colours have been set:\n\r");
         strcat (buf,
             " Code | Name            | Color\n\r"
             "-------------------------------------------------------------------------\n\r");
@@ -93,26 +93,26 @@ void do_colour_codes (CHAR_T *ch, char *argument) {
     flag_t last_mask = 0;
     int i, col = 0;
 
-    send_to_char ("Valid colours:\n\r", ch);
+    printf_to_char (ch, "Valid colours:\n\r");
     for (i = 0; colour_table[i].name != NULL; i++) {
         if (last_mask != 0 && colour_table[i].mask != last_mask) {
             if (col != 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
             col = 0;
         }
         if (col == 0)
-            send_to_char ("    ", ch);
+            printf_to_char (ch, "    ");
 
         last_mask = colour_table[i].mask;
         printf_to_char (ch, "%-15s", colour_table[i].name);
 
         if (++col == 4) {
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
             col = 0;
         }
     }
     if (col != 0)
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
 }
 
 /* changes your scroll */
@@ -123,7 +123,7 @@ DEFINE_DO_FUN (do_scroll) {
     one_argument (argument, arg);
     if (arg[0] == '\0') {
         if (ch->lines == 0)
-            send_to_char ("You do not page long messages.\n\r", ch);
+            printf_to_char (ch, "You do not page long messages.\n\r");
         else {
             printf_to_char (ch, "You currently display %d lines per page.\n\r",
                 ch->lines + 2);
@@ -135,7 +135,7 @@ DEFINE_DO_FUN (do_scroll) {
 
     lines = atoi (arg);
     if (lines == 0) {
-        send_to_char ("Paging disabled.\n\r", ch);
+        printf_to_char (ch, "Paging disabled.\n\r");
         ch->lines = 0;
         return;
     }
@@ -242,8 +242,8 @@ DEFINE_DO_FUN (do_autolist) {
     BAIL_IF (IS_NPC (ch),
         "NPCs can't use player flags.\n\r", ch);
 
-    send_to_char ("   action         status\n\r", ch);
-    send_to_char ("---------------------------\n\r", ch);
+    printf_to_char (ch, "   action         status\n\r");
+    printf_to_char (ch, "---------------------------\n\r");
 
     do_autolist_ext_flag ("autoassist",   ch, ch->ext_plr,  PLR_AUTOASSIST);
     do_autolist_ext_flag ("autoexit",     ch, ch->ext_plr,  PLR_AUTOEXIT);
@@ -252,7 +252,7 @@ DEFINE_DO_FUN (do_autolist) {
     do_autolist_ext_flag ("autosac",      ch, ch->ext_plr,  PLR_AUTOSAC);
     do_autolist_ext_flag ("autosplit",    ch, ch->ext_plr,  PLR_AUTOSPLIT);
 
-    send_to_char ("---------------------------\n\r", ch);
+    printf_to_char (ch, "---------------------------\n\r");
     do_autolist_flag ("telnetga",     ch, ch->comm, COMM_TELNET_GA);
     do_autolist_flag ("brief",        ch, ch->comm, COMM_BRIEF);
     do_autolist_flag ("compactmode",  ch, ch->comm, COMM_COMPACT);
@@ -263,7 +263,7 @@ DEFINE_DO_FUN (do_autolist) {
     do_autolist_flag ("materials",    ch, ch->comm, COMM_MATERIALS);
 #endif
 
-    send_to_char ("---------------------------\n\r", ch);
+    printf_to_char (ch, "---------------------------\n\r");
     do_autolist_ext_flag ("noloot",       ch, EXT_INVERTED (ch->ext_plr), PLR_CANLOOT);
     do_autolist_ext_flag ("nosummon",     ch, ch->ext_plr,  PLR_NOSUMMON);
     do_autolist_ext_flag ("nofollow",     ch, ch->ext_plr,  PLR_NOFOLLOW);
@@ -379,7 +379,7 @@ DEFINE_DO_FUN (do_autoall) {
         EXT_SET (ch->ext_plr, PLR_AUTOLOOT);
         EXT_SET (ch->ext_plr, PLR_AUTOSAC);
         EXT_SET (ch->ext_plr, PLR_AUTOSPLIT);
-        send_to_char ("All autos turned on.\n\r", ch);
+        printf_to_char (ch, "All autos turned on.\n\r");
     }
     else if (!strcmp (argument, "off")) {
         EXT_UNSET (ch->ext_plr, PLR_AUTOASSIST);
@@ -388,10 +388,10 @@ DEFINE_DO_FUN (do_autoall) {
         EXT_UNSET (ch->ext_plr, PLR_AUTOLOOT);
         EXT_UNSET (ch->ext_plr, PLR_AUTOSAC);
         EXT_UNSET (ch->ext_plr, PLR_AUTOSPLIT);
-        send_to_char ("All autos turned off.\n\r", ch);
+        printf_to_char (ch, "All autos turned off.\n\r");
     }
     else
-        send_to_char ("Usage: autoall [on|off]\n\r", ch);
+        printf_to_char (ch, "Usage: autoall [on|off]\n\r");
 }
 
 DEFINE_DO_FUN (do_prompt) {
@@ -426,7 +426,7 @@ DEFINE_DO_FUN (do_prompt) {
 }
 
 DEFINE_DO_FUN (do_alia) {
-    send_to_char ("I'm sorry, alias must be entered in full.\n\r", ch);
+    printf_to_char (ch, "I'm sorry, alias must be entered in full.\n\r");
 }
 
 DEFINE_DO_FUN (do_alias) {
@@ -444,7 +444,7 @@ DEFINE_DO_FUN (do_alias) {
         BAIL_IF (rch->pcdata->alias[0] == NULL,
             "You have no aliases defined.\n\r", ch);
 
-        send_to_char ("Your current aliases are:\n\r", ch);
+        printf_to_char (ch, "Your current aliases are:\n\r");
         for (pos = 0; pos < MAX_ALIAS; pos++) {
             if (rch->pcdata->alias[pos] == NULL
                 || rch->pcdata->alias_sub[pos] == NULL)
@@ -477,7 +477,7 @@ DEFINE_DO_FUN (do_alias) {
                 return;
             }
         }
-        send_to_char ("That alias is not defined.\n\r", ch);
+        printf_to_char (ch, "That alias is not defined.\n\r");
         return;
     }
 
@@ -530,7 +530,7 @@ DEFINE_DO_FUN (do_unalias) {
         }
 
         if (!strcmp (arg, rch->pcdata->alias[pos])) {
-            send_to_char ("Alias removed.\n\r", ch);
+            printf_to_char (ch, "Alias removed.\n\r");
             str_free (&(rch->pcdata->alias[pos]));
             str_free (&(rch->pcdata->alias_sub[pos]));
             rch->pcdata->alias[pos] = NULL;
@@ -540,5 +540,5 @@ DEFINE_DO_FUN (do_unalias) {
     }
 
     if (!found)
-        send_to_char ("No alias of that name to remove.\n\r", ch);
+        printf_to_char (ch, "No alias of that name to remove.\n\r");
 }

--- a/src/act_fight.c
+++ b/src/act_fight.c
@@ -104,7 +104,7 @@ DEFINE_DO_FUN (do_berserk) {
         (!IS_NPC (ch) && ch->level <
             skill_table[SN(BERSERK)].classes[ch->class].level))
     {
-        send_to_char ("You turn red in the face, but nothing happens.\n\r", ch);
+        printf_to_char (ch, "You turn red in the face, but nothing happens.\n\r");
         return;
     }
 
@@ -133,7 +133,7 @@ DEFINE_DO_FUN (do_berserk) {
         ch->mana -= 25;
         ch->move /= 2;
 
-        send_to_char ("Your pulse speeds up, but nothing happens.\n\r", ch);
+        printf_to_char (ch, "Your pulse speeds up, but nothing happens.\n\r");
         player_try_skill_improve (ch, SN(BERSERK), FALSE, 2);
         return;
     }
@@ -146,7 +146,7 @@ DEFINE_DO_FUN (do_berserk) {
     ch->hit += ch->level * 2;
     ch->hit = UMIN (ch->hit, ch->max_hit);
 
-    send_to_char ("Your pulse races as you are consumed by rage!\n\r", ch);
+    printf_to_char (ch, "Your pulse races as you are consumed by rage!\n\r");
     act ("$n gets a wild look in $s eyes.", ch, NULL, NULL, TO_NOTCHAR);
     player_try_skill_improve (ch, SN(BERSERK), TRUE, 2);
 
@@ -297,7 +297,7 @@ DEFINE_DO_FUN (do_dirt) {
             ch, NULL, victim, 0, POS_RESTING);
 
         damage_quiet (ch, victim, number_range (2, 5), SN(DIRT), DAM_NONE);
-        send_to_char ("{5You can't see a thing!{x\n\r", victim);
+        printf_to_char (victim, "{5You can't see a thing!{x\n\r");
 
         player_try_skill_improve (ch, SN(DIRT), TRUE, 2);
         WAIT_STATE (ch, skill_table[SN(DIRT)].beats);
@@ -333,7 +333,7 @@ DEFINE_DO_FUN (do_trip) {
         "$N is your beloved master.", ch, NULL, victim);
 
     if (victim == ch) {
-        send_to_char ("{5You fall flat on your face!{x\n\r", ch);
+        printf_to_char (ch, "{5You fall flat on your face!{x\n\r");
         WAIT_STATE (ch, 2 * skill_table[SN(TRIP)].beats);
         act ("{5$n trips over $s own feet!{x", ch, NULL, NULL, TO_NOTCHAR);
         return;
@@ -425,7 +425,7 @@ DEFINE_DO_FUN (do_kill) {
 */
 
     if (victim == ch) {
-        send_to_char ("You hit yourself.  Ouch!\n\r", ch);
+        printf_to_char (ch, "You hit yourself.  Ouch!\n\r");
         multi_hit (ch, ch, ATTACK_DEFAULT);
         return;
     }
@@ -444,7 +444,7 @@ DEFINE_DO_FUN (do_kill) {
 }
 
 DEFINE_DO_FUN (do_murde) {
-    send_to_char ("If you want to MURDER, spell it out.\n\r", ch);
+    printf_to_char (ch, "If you want to MURDER, spell it out.\n\r");
 }
 
 DEFINE_DO_FUN (do_murder) {
@@ -529,7 +529,7 @@ DEFINE_DO_FUN (do_flee) {
     if ((victim = ch->fighting) == NULL) {
         if (ch->position == POS_FIGHTING)
             ch->position = POS_STANDING;
-        send_to_char ("You aren't fighting anyone.\n\r", ch);
+        printf_to_char (ch, "You aren't fighting anyone.\n\r");
         return;
     }
     BAIL_IF (ch->daze > 0,
@@ -562,14 +562,14 @@ DEFINE_DO_FUN (do_flee) {
 
         if (!IS_NPC (ch)) {
             const CLASS_T *class;
-            send_to_char ("You flee from combat!\n\r", ch);
+            printf_to_char (ch, "You flee from combat!\n\r");
 
             class = class_get (ch->class);
             if (class != NULL && class->can_sneak_away &&
                     (number_percent () < 3 * (ch->level / 2)))
-                send_to_char ("You snuck away safely.\n\r", ch);
+                printf_to_char (ch, "You snuck away safely.\n\r");
             else {
-                send_to_char ("You lost 10 exp.\n\r", ch);
+                printf_to_char (ch, "You lost 10 exp.\n\r");
                 player_gain_exp (ch, -10);
             }
         }
@@ -577,7 +577,7 @@ DEFINE_DO_FUN (do_flee) {
         stop_fighting (ch, TRUE);
         return;
     }
-    send_to_char ("PANIC! You couldn't escape!\n\r", ch);
+    printf_to_char (ch, "PANIC! You couldn't escape!\n\r");
 }
 
 DEFINE_DO_FUN (do_rescue) {
@@ -603,7 +603,7 @@ DEFINE_DO_FUN (do_rescue) {
 
     WAIT_STATE (ch, skill_table[SN(RESCUE)].beats);
     if (number_percent () > char_get_skill (ch, SN(RESCUE))) {
-        send_to_char ("You fail the rescue.\n\r", ch);
+        printf_to_char (ch, "You fail the rescue.\n\r");
         player_try_skill_improve (ch, SN(RESCUE), FALSE, 1);
         return;
     }

--- a/src/act_group.c
+++ b/src/act_group.c
@@ -109,7 +109,7 @@ DEFINE_DO_FUN (do_order) {
         printf_to_char(ch, "You ordered %s to %s.\n\r", arg, argument);
     }
     else
-        send_to_char ("You have no followers here.\n\r", ch);
+        printf_to_char (ch, "You have no followers here.\n\r");
 }
 
 DEFINE_DO_FUN (do_group) {

--- a/src/act_info.c
+++ b/src/act_info.c
@@ -121,7 +121,7 @@ void do_scan_real (CHAR_T *ch, char *argument, int max_depth) {
     if (arg1[0] == '\0') {
         min_depth = 0;
         door = SCAN_ALL_DIRS;
-        send_to_char ("Looking around you see:\n\r", ch);
+        printf_to_char (ch, "Looking around you see:\n\r");
         act ("$n looks all around.", ch, NULL, NULL, TO_NOTCHAR);
     }
     else if ((door = door_lookup (arg1)) >= 0) {
@@ -132,7 +132,7 @@ void do_scan_real (CHAR_T *ch, char *argument, int max_depth) {
         max_depth *= 2;
     }
     else {
-        send_to_char ("That's not a valid direction.\n\r", ch);
+        printf_to_char (ch, "That's not a valid direction.\n\r");
         return;
     }
 
@@ -167,7 +167,7 @@ void do_look_room (CHAR_T *ch, int is_auto) {
     if ((IS_IMMORTAL (ch) && (IS_NPC (ch) || EXT_IS_SET (ch->ext_plr, PLR_HOLYLIGHT)))
         || IS_BUILDER (ch, ch->in_room->area))
         printf_to_char (ch, "{r [{RRoom %d{r]{x", ch->in_room->vnum);
-    send_to_char ("\n\r", ch);
+    printf_to_char (ch, "\n\r");
 
     if (!is_auto || (!IS_NPC (ch) && !IS_SET (ch->comm, COMM_BRIEF)))
         printf_to_char(ch, "  {S%s{x", ch->in_room->description);
@@ -199,7 +199,7 @@ void do_look_direction (CHAR_T *ch, int door) {
     if (pexit->description != NULL && pexit->description[0] != '\0')
         send_to_char (pexit->description, ch);
     else
-        send_to_char ("Nothing special there.\n\r", ch);
+        printf_to_char (ch, "Nothing special there.\n\r");
 
     if (pexit->keyword != NULL && pexit->keyword[0] != '\0' &&
         pexit->keyword[0] != ' ')
@@ -231,7 +231,7 @@ bool do_filter_description_remove_line (CHAR_T *ch) {
                 buf[len + 1] = '\0';
                 str_free (&(ch->description));
                 ch->description = str_dup (buf);
-                send_to_char ("Your description is:\n\r", ch);
+                printf_to_char (ch, "Your description is:\n\r");
                 send_to_char (ch->description ? ch->description :
                               "(None).\n\r", ch);
                 return FALSE;
@@ -242,7 +242,7 @@ bool do_filter_description_remove_line (CHAR_T *ch) {
     buf[0] = '\0';
     str_free (&(ch->description));
     ch->description = str_dup (buf);
-    send_to_char ("Description cleared.\n\r", ch);
+    printf_to_char (ch, "Description cleared.\n\r");
     return FALSE;
 }
 
@@ -312,7 +312,7 @@ DEFINE_DO_FUN (do_look) {
     if (!IS_NPC (ch) && !EXT_IS_SET (ch->ext_plr, PLR_HOLYLIGHT) &&
         room_is_dark (ch->in_room))
     {
-        send_to_char ("{DIt is pitch black ... {x\n\r", ch);
+        printf_to_char (ch, "{DIt is pitch black ... {x\n\r");
         char_list_show_to_char (ch->in_room->people_first, ch);
         return;
     }
@@ -345,7 +345,7 @@ DEFINE_DO_FUN (do_look) {
             if (++count == number) { \
                 send_to_char ((str), ch); \
                 if ((with_crlf)) \
-                    send_to_char ("\n\r", ch); \
+                    printf_to_char (ch, "\n\r"); \
                 return; \
             } \
             continue; \
@@ -395,7 +395,7 @@ DEFINE_DO_FUN (do_look) {
     }
 
     /* All options failed. */
-    send_to_char ("You do not see that here.\n\r", ch);
+    printf_to_char (ch, "You do not see that here.\n\r");
 }
 
 /* RT added back for the hell of it */
@@ -512,11 +512,11 @@ DEFINE_DO_FUN (do_score) {
     printf_to_char (ch, "Wimpy set to %d hit points.\n\r", ch->wimpy);
 
     if (IS_DRUNK (ch))
-        send_to_char ("You are drunk.\n\r", ch);
+        printf_to_char (ch, "You are drunk.\n\r");
     if (IS_THIRSTY (ch))
-        send_to_char ("You are thirsty.\n\r", ch);
+        printf_to_char (ch, "You are thirsty.\n\r");
     if (IS_HUNGRY (ch))
-        send_to_char ("You are hungry.\n\r", ch);
+        printf_to_char (ch, "You are hungry.\n\r");
 
     printf_to_char (ch, "You are %s\r\n",
         char_get_position_str (ch, ch->position, ch->on, TRUE));
@@ -548,7 +548,7 @@ DEFINE_DO_FUN (do_score) {
             printf_to_char (ch, "  Invisible: level %d", ch->invis_level);
         if (ch->incog_level)
             printf_to_char (ch, "  Incognito: level %d", ch->incog_level);
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
     }
 
     if (IS_SET (ch->comm, COMM_SHOW_AFFECTS))
@@ -561,7 +561,7 @@ DEFINE_DO_FUN (do_affects) {
     BAIL_IF (ch->affect_first == NULL,
         "You are not affected by any spells.\n\r", ch);
 
-    send_to_char ("You are affected by the following spells:\n\r", ch);
+    printf_to_char (ch, "You are affected by the following spells:\n\r");
     for (paf = ch->affect_first; paf != NULL; paf = paf->on_next) {
         if (paf_last == NULL || paf->type != paf_last->type)
             printf_to_char (ch, "Spell: %-15s\n\r", skill_table[paf->type].name);
@@ -575,7 +575,7 @@ DEFINE_DO_FUN (do_affects) {
                 printf_to_char (ch, "   modifies %s by %d ",
                     affect_apply_name (paf->apply), paf->modifier);
             if (paf->duration == -1)
-                send_to_char ("permanently\n\r", ch);
+                printf_to_char (ch, "permanently\n\r");
             else
                 printf_to_char (ch, "for %d hours\n\r", paf->duration);
         }
@@ -675,14 +675,14 @@ DEFINE_DO_FUN (do_help) {
     }
 
     if (!found) {
-        send_to_char ("No help on that word.\n\r", ch);
+        printf_to_char (ch, "No help on that word.\n\r");
         /* Let's log unmet help requests so studious IMP's can improve their help files ;-)
          * But to avoid idiots, we will check the length of the help request, and trim to
          * a reasonable length (set it by redefining MAX_CMD_LEN in merc.h).  -- JR */
         if (strlen(argall) > MAX_CMD_LEN) {
             argall[MAX_CMD_LEN - 1] = '\0';
             log_f ("Excessive command length: %s requested %s.", ch->name, argall);
-            send_to_char ("That was rude!\n\r", ch);
+            printf_to_char (ch, "That was rude!\n\r");
         }
         /* OHELPS_FILE is the "orphaned helps" files. Defined in merc.h -- JR */
         else
@@ -769,7 +769,7 @@ DEFINE_DO_FUN (do_who) {
                 case 1: level_lower = atoi (arg); break;
                 case 2: level_upper = atoi (arg); break;
                 default:
-                    send_to_char ("Only two level numbers allowed.\n\r", ch);
+                    printf_to_char (ch, "Only two level numbers allowed.\n\r");
                     return;
             }
             continue;
@@ -813,7 +813,7 @@ DEFINE_DO_FUN (do_who) {
         }
 
         /* Unknown argument. */
-        send_to_char ("That's not a valid race, class, or clan.\n\r", ch);
+        printf_to_char (ch, "That's not a valid race, class, or clan.\n\r");
         return;
     }
 
@@ -881,7 +881,7 @@ DEFINE_DO_FUN (do_count) {
 }
 
 DEFINE_DO_FUN (do_inventory) {
-    send_to_char ("You are carrying:\n\r", ch);
+    printf_to_char (ch, "You are carrying:\n\r");
     obj_list_show_to_char (ch->content_first, ch, TRUE, TRUE);
 }
 
@@ -891,7 +891,7 @@ DEFINE_DO_FUN (do_equipment) {
     int wear_loc;
     bool found;
 
-    send_to_char ("You are using:\n\r", ch);
+    printf_to_char (ch, "You are using:\n\r");
     found = FALSE;
     for (wear_loc = 0; wear_loc < WEAR_LOC_MAX; wear_loc++) {
         if ((obj = char_get_eq_by_wear_loc (ch, wear_loc)) == NULL)
@@ -903,12 +903,12 @@ DEFINE_DO_FUN (do_equipment) {
         if (char_can_see_obj (ch, obj))
             printf_to_char (ch, "%s\n\r", obj_format_to_char (obj, ch, TRUE));
         else
-            send_to_char ("something.\n\r", ch);
+            printf_to_char (ch, "something.\n\r");
         found = TRUE;
     }
 
     if (!found)
-        send_to_char ("Nothing.\n\r", ch);
+        printf_to_char (ch, "Nothing.\n\r");
 }
 
 DEFINE_DO_FUN (do_compare) {
@@ -980,7 +980,7 @@ DEFINE_DO_FUN (do_where) {
     one_argument (argument, arg);
 
     if (arg[0] == '\0') {
-        send_to_char ("Players near you:\n\r", ch);
+        printf_to_char (ch, "Players near you:\n\r");
         found = FALSE;
         for (d = descriptor_first; d; d = d->global_next) {
             if (d->connected == CON_PLAYING
@@ -998,7 +998,7 @@ DEFINE_DO_FUN (do_where) {
             }
         }
         if (!found)
-            send_to_char ("None\n\r", ch);
+            printf_to_char (ch, "None\n\r");
     }
     else {
         found = FALSE;
@@ -1052,7 +1052,7 @@ DEFINE_DO_FUN (do_description) {
         if (do_filter_description_alter (ch, argument))
             return;
 
-    send_to_char ("Your description is:\n\r", ch);
+    printf_to_char (ch, "Your description is:\n\r");
     send_to_char (ch->description ? ch->description : "(None).\n\r", ch);
 }
 
@@ -1075,12 +1075,12 @@ DEFINE_DO_FUN (do_commands) {
         {
             printf_to_char (ch, "%-12s", cmd_table[cmd].name);
             if (++col % 6 == 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
         }
     }
 
     if (col % 6 != 0)
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
 }
 
 DEFINE_DO_FUN (do_areas) {

--- a/src/act_info.c
+++ b/src/act_info.c
@@ -197,7 +197,7 @@ void do_look_direction (CHAR_T *ch, int door) {
         "Nothing special there.\n\r", ch);
 
     if (pexit->description != NULL && pexit->description[0] != '\0')
-        send_to_char (pexit->description, ch);
+        printf_to_char (ch, pexit->description);
     else
         printf_to_char (ch, "Nothing special there.\n\r");
 
@@ -343,7 +343,7 @@ DEFINE_DO_FUN (do_look) {
     #define CHECK_LOOK(cond, str, with_crlf) \
         if ((cond)) { \
             if (++count == number) { \
-                send_to_char ((str), ch); \
+                printf_to_char (ch, (str)); \
                 if ((with_crlf)) \
                     printf_to_char (ch, "\n\r"); \
                 return; \
@@ -444,7 +444,7 @@ DEFINE_DO_FUN (do_exits) {
         sprintf (buf, "Obvious exits from room %d:\n\r", ch->in_room->vnum);
     else
         sprintf (buf, "Obvious exits:\n\r");
-    send_to_char (buf, ch);
+    printf_to_char (ch, buf);
 
     mode = auto_exits ? EXITS_AUTO : EXITS_LONG;
     char_format_exit_string (ch, ch->in_room, mode, buf, sizeof (buf));
@@ -1053,7 +1053,7 @@ DEFINE_DO_FUN (do_description) {
             return;
 
     printf_to_char (ch, "Your description is:\n\r");
-    send_to_char (ch->description ? ch->description : "(None).\n\r", ch);
+    printf_to_char (ch, ch->description ? ch->description : "(None).\n\r");
 }
 
 DEFINE_DO_FUN (do_report) {

--- a/src/act_move.c
+++ b/src/act_move.c
@@ -90,7 +90,7 @@ bool do_door_filter_is_door (CHAR_T *ch, EXIT_T *pexit,
                 container = TRUE;
                 break;
             default:
-                send_to_char ("That's not a container.\n\r", ch);
+                printf_to_char (ch, "That's not a container.\n\r");
                 return TRUE;
         }
     }
@@ -208,7 +208,7 @@ bool do_door_filter_can_pick (CHAR_T *ch, EXIT_T *pexit, OBJ_T *obj) {
 
     /* pick-specific checks. */
     if (!IS_NPC (ch) && number_percent () > char_get_skill (ch, SN(PICK_LOCK))) {
-        send_to_char ("You failed.\n\r", ch);
+        printf_to_char (ch, "You failed.\n\r");
         player_try_skill_improve (ch, SN(PICK_LOCK), FALSE, 2);
         return TRUE;
     }
@@ -574,7 +574,7 @@ DEFINE_DO_FUN (do_wake) {
 DEFINE_DO_FUN (do_sneak) {
     AFFECT_T af;
 
-    send_to_char ("You attempt to move silently.\n\r", ch);
+    printf_to_char (ch, "You attempt to move silently.\n\r");
     affect_strip_char (ch, SN(SNEAK));
 
     if (IS_AFFECTED (ch, AFF_SNEAK))
@@ -589,7 +589,7 @@ DEFINE_DO_FUN (do_sneak) {
 }
 
 DEFINE_DO_FUN (do_hide) {
-    send_to_char ("You attempt to hide.\n\r", ch);
+    printf_to_char (ch, "You attempt to hide.\n\r");
 
     if (IS_AFFECTED (ch, AFF_HIDE))
         REMOVE_BIT (ch->affected_by, AFF_HIDE);
@@ -637,7 +637,7 @@ DEFINE_DO_FUN (do_recall) {
         if (number_percent () < 80 * skill / 100) {
             player_try_skill_improve (ch, SN(RECALL), FALSE, 6);
             WAIT_STATE (ch, 4);
-            send_to_char ("You failed!\n\r", ch);
+            printf_to_char (ch, "You failed!\n\r");
             return;
         }
 
@@ -678,5 +678,5 @@ DEFINE_DO_FUN (do_enter) {
 
     /* Enter the portal. */
     if (!item_enter_effect (portal, ch))
-        send_to_char ("You can't enter that.\n\r", ch);
+        printf_to_char (ch, "You can't enter that.\n\r");
 }

--- a/src/act_obj.c
+++ b/src/act_obj.c
@@ -1012,7 +1012,7 @@ DEFINE_DO_FUN (do_steal) {
             sprintf (buf, "Bingo!  You got %d silver and %d gold coins.\n\r",
                      silver, gold);
 
-        send_to_char (buf, ch);
+        printf_to_char (ch, buf);
         player_try_skill_improve (ch, SN(STEAL), TRUE, 2);
         return;
     }

--- a/src/act_obj.c
+++ b/src/act_obj.c
@@ -210,7 +210,7 @@ void do_get_room (CHAR_T *ch, char *argument) {
     }
     if (!found) {
         if (type == OBJ_ALL)
-            send_to_char ("You see nothing here.\n\r", ch);
+            printf_to_char (ch, "You see nothing here.\n\r");
         else if (type == OBJ_ALL_OF || failed || obj_start == NULL)
             act ("You see no $T here.", ch, NULL, argument, TO_CHAR);
     }
@@ -266,7 +266,7 @@ DEFINE_DO_FUN (do_put) {
     }
     if (!found) {
         if (type == OBJ_ALL)
-            send_to_char ("You are not carrying anything.\n\r", ch);
+            printf_to_char (ch, "You are not carrying anything.\n\r");
         else if (type == OBJ_ALL_OF || failed || obj_start == NULL)
             act ("You are not carrying any $T.", ch, NULL, arg, TO_CHAR);
     }
@@ -335,7 +335,7 @@ DEFINE_DO_FUN (do_drop) {
     }
     if (!found) {
         if (type == OBJ_ALL)
-            send_to_char ("You are not carrying anything.\n\r", ch);
+            printf_to_char (ch, "You are not carrying anything.\n\r");
         else if (type == OBJ_ALL_OF || failed || obj_start == NULL)
             act ("You are not carrying any $T.", ch, NULL, arg, TO_CHAR);
     }
@@ -631,7 +631,7 @@ DEFINE_DO_FUN (do_drink) {
          ch, obj, liq->name, 0, POS_RESTING);
 
     if (!item_drink_effect (obj, ch))
-        send_to_char ("...but nothing happens.\n\r", ch);
+        printf_to_char (ch, "...but nothing happens.\n\r");
 }
 
 DEFINE_DO_FUN (do_eat) {
@@ -650,7 +650,7 @@ DEFINE_DO_FUN (do_eat) {
 
     act2 ("You eat $p.", "$n eats $p.", ch, obj, NULL, 0, POS_RESTING);
     if (!item_eat_effect (obj, ch))
-        send_to_char ("...but nothing happens.\n\r", ch);
+        printf_to_char (ch, "...but nothing happens.\n\r");
 }
 
 DEFINE_DO_FUN (do_wear) {
@@ -731,7 +731,7 @@ DEFINE_DO_FUN (do_sacrifice) {
 #endif
 
     if (silver == 1)
-        send_to_char ("Mota gives you one silver coin for your sacrifice.\n\r", ch);
+        printf_to_char (ch, "Mota gives you one silver coin for your sacrifice.\n\r");
     else {
         printf_to_char (ch, "Mota gives you %d silver coins for your sacrifice.\n\r",
             silver);
@@ -770,7 +770,7 @@ DEFINE_DO_FUN (do_quaff) {
         ch, obj, NULL, 0, POS_RESTING);
 
     if (!item_quaff_effect (obj, ch))
-        send_to_char ("...but nothing happens.\n\r", ch);
+        printf_to_char (ch, "...but nothing happens.\n\r");
 }
 
 DEFINE_DO_FUN (do_recite) {
@@ -802,14 +802,14 @@ DEFINE_DO_FUN (do_recite) {
         ch, scroll, NULL, 0, POS_RESTING);
 
     if (number_percent () >= 20 + char_get_skill (ch, SN(SCROLLS)) * 4 / 5) {
-        send_to_char ("You mispronounce a syllable.\n\r", ch);
+        printf_to_char (ch, "You mispronounce a syllable.\n\r");
         player_try_skill_improve (ch, SN(SCROLLS), FALSE, 2);
         obj_extract (scroll);
         return;
     }
 
     if (!item_recite_effect (scroll, ch, victim, obj)) {
-        send_to_char ("...but nothing happens.\n\r", ch);
+        printf_to_char (ch, "...but nothing happens.\n\r");
         return;
     }
 
@@ -947,7 +947,7 @@ DEFINE_DO_FUN (do_steal) {
         || (!IS_NPC (ch) && !player_has_clan (ch)))
     {
         /* Failure. */
-        send_to_char ("Oops.\n\r", ch);
+        printf_to_char (ch, "Oops.\n\r");
         affect_strip_char (ch, SN(SNEAK));
         REMOVE_BIT (ch->affected_by, AFF_SNEAK);
 
@@ -982,7 +982,7 @@ DEFINE_DO_FUN (do_steal) {
                     "$N tried to steal from %s.", victim->name);
                 if (!EXT_IS_SET (ch->ext_plr, PLR_THIEF)) {
                     EXT_SET (ch->ext_plr, PLR_THIEF);
-                    send_to_char ("*** You are now a THIEF!! ***\n\r", ch);
+                    printf_to_char (ch, "*** You are now a THIEF!! ***\n\r");
                     save_char_obj (ch);
                 }
             }
@@ -1033,7 +1033,7 @@ DEFINE_DO_FUN (do_steal) {
     obj_give_to_char (obj, ch);
     act ("You pocket $p.", ch, obj, NULL, TO_CHAR);
     player_try_skill_improve (ch, SN(STEAL), TRUE, 2);
-    send_to_char ("Got it!\n\r", ch);
+    printf_to_char (ch, "Got it!\n\r");
 }
 
 /* equips a character */
@@ -1087,7 +1087,7 @@ DEFINE_DO_FUN (do_outfit) {
         char_equip_obj (ch, obj, WEAR_LOC_SHIELD);
     }
 
-    send_to_char ("You have been equipped by Mota.\n\r", ch);
+    printf_to_char (ch, "You have been equipped by Mota.\n\r");
 }
 
 DEFINE_DO_FUN (do_play) {
@@ -1098,5 +1098,5 @@ DEFINE_DO_FUN (do_play) {
         "You see nothing to play.\n\r", ch);
 
     if (!item_play_effect (juke, ch, argument))
-        send_to_char ("Nothing happens.\n\r", ch);
+        printf_to_char (ch, "Nothing happens.\n\r");
 }

--- a/src/act_olc.c
+++ b/src/act_olc.c
@@ -221,7 +221,7 @@ void do_resets_display (CHAR_T *ch) {
                 strcat (final, buf);
                 break;
         }
-        send_to_char (final, ch);
+        printf_to_char (ch, final);
     }
 }
 
@@ -669,7 +669,7 @@ DEFINE_DO_FUN (do_resets) {
     }
 
     /* No valid reset found. */
-    send_to_char (DO_RESETS_SYNTAX, ch);
+    printf_to_char (ch, DO_RESETS_SYNTAX);
 }
 
 /*****************************************************************************
@@ -697,7 +697,7 @@ DEFINE_DO_FUN (do_alist) {
         strcat (result, buf);
     }
 
-    send_to_char (result, ch);
+    printf_to_char (ch, result);
 }
 
 /*****************************************************************************
@@ -801,7 +801,7 @@ DEFINE_DO_FUN (do_asave) {
         save_other_helps (ch);
         if (!str_cmp (buf, "None.\n\r")) {
             if (ch)
-                send_to_char (buf, ch);
+                printf_to_char (ch, buf);
             else
                 log_string ("None.");
         }
@@ -909,7 +909,7 @@ DEFINE_DO_FUN (do_portals) {
     else if (arg2[0] != '\0' && !str_prefix (arg2, "world"))
         area = NULL;
     else {
-        send_to_char (DO_PORTALS_SYNTAX, ch);
+        printf_to_char (ch, DO_PORTALS_SYNTAX);
         return;
     }
 
@@ -1004,5 +1004,5 @@ DEFINE_DO_FUN (do_portals) {
     }
 
     /* no matches - show syntax. */
-    send_to_char (DO_PORTALS_SYNTAX, ch);
+    printf_to_char (ch, DO_PORTALS_SYNTAX);
 }

--- a/src/act_olc.c
+++ b/src/act_olc.c
@@ -322,7 +322,7 @@ DEFINE_DO_FUN (do_hedit) {
             return;
         }
     }
-    send_to_char ("HEdit: There is no default help to edit.\n\r", ch);
+    printf_to_char (ch, "HEdit: There is no default help to edit.\n\r");
 }
 
 /* Entry point for editing mob_index_data. */
@@ -364,7 +364,7 @@ DEFINE_DO_FUN (do_medit) {
         return;
     }
 
-    send_to_char ("MEdit: There is no default mobile to edit.\n\r", ch);
+    printf_to_char (ch, "MEdit: There is no default mobile to edit.\n\r");
 }
 
 DEFINE_DO_FUN (do_mpedit) {
@@ -396,8 +396,8 @@ DEFINE_DO_FUN (do_mpedit) {
         return;
     }
 
-    send_to_char ("Syntax: mpedit [vnum]\n\r", ch);
-    send_to_char ("        mpedit create [vnum]\n\r", ch);
+    printf_to_char (ch, "Syntax: mpedit [vnum]\n\r");
+    printf_to_char (ch, "        mpedit create [vnum]\n\r");
 }
 
 /* Entry point for editing obj_index_data. */
@@ -439,7 +439,7 @@ DEFINE_DO_FUN (do_oedit) {
         return;
     }
 
-    send_to_char ("OEdit: There is no default object to edit.\n\r", ch);
+    printf_to_char (ch, "OEdit: There is no default object to edit.\n\r");
 }
 
 /* Entry point for editing room_index_data. */
@@ -461,7 +461,7 @@ DEFINE_DO_FUN (do_redit) {
             "REdit: Insufficient security to modify room.\n\r", ch);
 
         room_reset (room);
-        send_to_char ("Room reset.\n\r", ch);
+        printf_to_char (ch, "Room reset.\n\r");
         return;
     }
     /* redit create <vnum> */
@@ -577,7 +577,7 @@ DEFINE_DO_FUN (do_resets) {
         }
 
         reset_data_free (reset);
-        send_to_char ("Reset deleted.\n\r", ch);
+        printf_to_char (ch, "Reset deleted.\n\r");
         return;
     }
 
@@ -649,7 +649,7 @@ DEFINE_DO_FUN (do_resets) {
         }
         reset_to_room_before (reset, ch->in_room, index);
         SET_BIT (ch->in_room->area->area_flags, AREA_CHANGED);
-        send_to_char ("Reset added.\n\r", ch);
+        printf_to_char (ch, "Reset added.\n\r");
         return;
     }
 
@@ -664,7 +664,7 @@ DEFINE_DO_FUN (do_resets) {
         v->randomize.dir_count = atoi (arg3);
         reset_to_room_before (reset, ch->in_room, index);
         SET_BIT (ch->in_room->area->area_flags, AREA_CHANGED);
-        send_to_char ("Random exits reset added.\n\r", ch);
+        printf_to_char (ch, "Random exits reset added.\n\r");
         return;
     }
 
@@ -738,14 +738,14 @@ DEFINE_DO_FUN (do_asave) {
         save_area_list ();
         json_export_portals (JSON_EXPORT_MODE_SAVE);
         save_area (area);
-        send_to_char ("Area saved.\n\r", ch);
+        printf_to_char (ch, "Area saved.\n\r");
         return;
     }
 
     /* Save the world, only authorized areas. */
     /* -------------------------------------- */
     if (!str_cmp ("world", arg1)) {
-        send_to_char ("Saving world...\n\r", ch);
+        printf_to_char (ch, "Saving world...\n\r");
         desc_flush_output (ch->desc);
         json_export_portals (JSON_EXPORT_MODE_SAVE);
         save_area_list ();
@@ -762,7 +762,7 @@ DEFINE_DO_FUN (do_asave) {
             REMOVE_BIT (area->area_flags, AREA_CHANGED);
         }
         if (ch)
-            send_to_char ("You saved the world.\n\r", ch);
+            printf_to_char (ch, "You saved the world.\n\r");
         save_other_helps (NULL);
         return;
     }
@@ -775,7 +775,7 @@ DEFINE_DO_FUN (do_asave) {
         json_export_portals (JSON_EXPORT_MODE_SAVE);
 
         if (ch)
-            send_to_char ("Saved zones:\n\r", ch);
+            printf_to_char (ch, "Saved zones:\n\r");
         else
             log_string ("Saved zones:");
         sprintf (buf, "None.\n\r");
@@ -812,7 +812,7 @@ DEFINE_DO_FUN (do_asave) {
     /* ----------------------- */
     if (!str_cmp (arg1, "list")) {
         save_area_list ();
-        send_to_char ("Area list saved.\n\r", ch);
+        printf_to_char (ch, "Area list saved.\n\r");
         return;
     }
 
@@ -820,7 +820,7 @@ DEFINE_DO_FUN (do_asave) {
     /* ----------------------- */
     if (!str_cmp (arg1, "portals")) {
         json_export_portals (JSON_EXPORT_MODE_SAVE);
-        send_to_char ("Portals saved.\n\r", ch);
+        printf_to_char (ch, "Portals saved.\n\r");
         return;
     }
 
@@ -852,10 +852,10 @@ DEFINE_DO_FUN (do_asave) {
             case ED_HELP: {
                 int saved;
 
-                send_to_char ("Saving all changed helps:\n\r", ch);
+                printf_to_char (ch, "Saving all changed helps:\n\r");
                 saved = save_other_helps (ch);
                 if (saved == 0)
-                    send_to_char ("No helps to save.\n\r", ch);
+                    printf_to_char (ch, "No helps to save.\n\r");
                 else
                     printf_to_char (ch, "%d helps to saved.\n\r", saved);
 
@@ -873,7 +873,7 @@ DEFINE_DO_FUN (do_asave) {
         json_export_portals (JSON_EXPORT_MODE_SAVE);
         save_area (area);
         REMOVE_BIT (area->area_flags, AREA_CHANGED);
-        send_to_char ("Area saved.\n\r", ch);
+        printf_to_char (ch, "Area saved.\n\r");
         return;
     }
 

--- a/src/act_player.c
+++ b/src/act_player.c
@@ -46,7 +46,7 @@
 
 /* RT code to delete yourself */
 DEFINE_DO_FUN (do_delet) {
-    send_to_char ("You must type the full command to delete yourself.\n\r", ch);
+    printf_to_char (ch, "You must type the full command to delete yourself.\n\r");
 }
 
 DEFINE_DO_FUN (do_delete) {
@@ -57,7 +57,7 @@ DEFINE_DO_FUN (do_delete) {
 
     if (ch->pcdata->confirm_delete) {
         if (argument[0] != '\0') {
-            send_to_char ("Delete status removed.\n\r", ch);
+            printf_to_char (ch, "Delete status removed.\n\r");
             ch->pcdata->confirm_delete = FALSE;
             return;
         }
@@ -85,11 +85,11 @@ DEFINE_DO_FUN (do_delete) {
 }
 
 DEFINE_DO_FUN (do_rent) {
-    send_to_char ("There is no rent here.  Just save and quit.\n\r", ch);
+    printf_to_char (ch, "There is no rent here.  Just save and quit.\n\r");
 }
 
 DEFINE_DO_FUN (do_qui) {
-    send_to_char ("If you want to QUIT, you have to spell it out.\n\r", ch);
+    printf_to_char (ch, "If you want to QUIT, you have to spell it out.\n\r");
 }
 
 DEFINE_DO_FUN (do_quit) {
@@ -104,7 +104,7 @@ DEFINE_DO_FUN (do_quit) {
     BAIL_IF (ch->position <= POS_STUNNED,
         "You're not DEAD yet.\n\r", ch);
 
-    send_to_char ("Alas, all good things must come to an end.\n\r", ch);
+    printf_to_char (ch, "Alas, all good things must come to an end.\n\r");
     act ("$n has left the game.", ch, NULL, NULL, TO_NOTCHAR);
     log_f ("%s has quit.", ch->name);
     wiznet ("$N rejoins the real world.", ch, NULL, WIZ_LOGINS, 0,
@@ -141,7 +141,7 @@ DEFINE_DO_FUN (do_save) {
         return;
 
     save_char_obj (ch);
-    send_to_char ("Saving. Remember that ROM has automatic saving now.\n\r", ch);
+    printf_to_char (ch, "Saving. Remember that ROM has automatic saving now.\n\r");
     WAIT_STATE (ch, PULSE_VIOLENCE);
 }
 
@@ -197,7 +197,7 @@ DEFINE_DO_FUN (do_password) {
 
     if (strcmp (crypt (arg1, ch->pcdata->pwd), ch->pcdata->pwd)) {
         WAIT_STATE (ch, 40);
-        send_to_char ("Wrong password.  Wait 10 seconds.\n\r", ch);
+        printf_to_char (ch, "Wrong password.  Wait 10 seconds.\n\r");
         return;
     }
     BAIL_IF (strlen (arg2) < 5,

--- a/src/act_shop.c
+++ b/src/act_shop.c
@@ -345,7 +345,7 @@ void do_list_items (CHAR_T *ch, char *argument) {
             sprintf (buf, "[%2d %5d %2d ] %s%s\n\r",
                 obj->level, cost, count, material_str, obj->short_descr);
         }
-        send_to_char (buf, ch);
+        printf_to_char (ch, buf);
     }
 
     if (!found)

--- a/src/act_shop.c
+++ b/src/act_shop.c
@@ -111,7 +111,7 @@ void do_buy_pet (CHAR_T *ch, char *argument) {
         room_index_next = room_get_index (ch->in_room->vnum + 1);
     if (room_index_next == NULL) {
         bug ("do_buy: bad pet shop at vnum %d.", ch->in_room->vnum);
-        send_to_char ("Sorry, you can't buy that here.\n\r", ch);
+        printf_to_char (ch, "Sorry, you can't buy that here.\n\r");
         return;
     }
 
@@ -159,7 +159,7 @@ void do_buy_pet (CHAR_T *ch, char *argument) {
     add_follower (pet, ch);
     pet->leader = ch;
     ch->pet = pet;
-    send_to_char ("Enjoy your pet.\n\r", ch);
+    printf_to_char (ch, "Enjoy your pet.\n\r");
     act ("$n bought $N as a pet.", ch, NULL, pet, TO_NOTCHAR);
 }
 
@@ -275,7 +275,7 @@ void do_list_pets (CHAR_T *ch, char *argument) {
         room_index_next = room_get_index (ch->in_room->vnum + 1);
     if (room_index_next == NULL) {
         bug ("do_list: bad pet shop at vnum %d.", ch->in_room->vnum);
-        send_to_char ("You can't do that here.\n\r", ch);
+        printf_to_char (ch, "You can't do that here.\n\r");
         return;
     }
 
@@ -285,7 +285,7 @@ void do_list_pets (CHAR_T *ch, char *argument) {
             continue;
         if (!found) {
             found = TRUE;
-            send_to_char ("Pets for sale:\n\r", ch);
+            printf_to_char (ch, "Pets for sale:\n\r");
         }
         material_str = IS_SET (ch->comm, COMM_MATERIALS)
             ? material_format_part (material_get (pet->material)) : "";
@@ -293,7 +293,7 @@ void do_list_pets (CHAR_T *ch, char *argument) {
             10 * pet->level * pet->level, material_str, pet->short_descr);
     }
     if (!found)
-        send_to_char ("Sorry, we're out of pets right now.\n\r", ch);
+        printf_to_char (ch, "Sorry, we're out of pets right now.\n\r");
 }
 
 void do_list_items (CHAR_T *ch, char *argument) {
@@ -322,7 +322,7 @@ void do_list_items (CHAR_T *ch, char *argument) {
 
         if (!found) {
             found = TRUE;
-            send_to_char ("[Lv Price Qty] Item\n\r", ch);
+            printf_to_char (ch, "[Lv Price Qty] Item\n\r");
         }
 
         material_str = IS_SET (ch->comm, COMM_MATERIALS)
@@ -349,7 +349,7 @@ void do_list_items (CHAR_T *ch, char *argument) {
     }
 
     if (!found)
-        send_to_char ("You can't buy anything here.\n\r", ch);
+        printf_to_char (ch, "You can't buy anything here.\n\r");
 }
 
 DEFINE_DO_FUN (do_list) {
@@ -389,7 +389,7 @@ DEFINE_DO_FUN (do_sell) {
     if (!IS_OBJ_STAT (obj, ITEM_SELL_EXTRACT)
         && roll < char_get_skill (ch, SN(HAGGLE)))
     {
-        send_to_char ("You haggle with the shopkeeper.\n\r", ch);
+        printf_to_char (ch, "You haggle with the shopkeeper.\n\r");
         cost += obj->cost / 2 * roll / 100;
         cost = UMIN (cost, 95 * mobile_get_obj_cost (keeper, obj, TRUE) / 100);
         cost = UMIN (cost, (keeper->silver + 100 * keeper->gold));
@@ -549,7 +549,7 @@ DEFINE_DO_FUN (do_heal) {
         ch->mana += dice (2, 8) + mob->level / 3;
         ch->mana = UMIN (ch->mana, ch->max_mana);
         say_spell_name (mob, "restore mana", class_lookup_exact ("cleric"));
-        send_to_char ("A warm glow passes through you.\n\r", ch);
+        printf_to_char (ch, "A warm glow passes through you.\n\r");
         return;
     }
     if (sn == -1)

--- a/src/act_skills.c
+++ b/src/act_skills.c
@@ -406,7 +406,7 @@ DEFINE_DO_FUN (do_train) {
 
         if (buf[strlen (buf) - 1] != ':') {
             strcat (buf, ".\n\r");
-            send_to_char (buf, ch);
+            printf_to_char (ch, buf);
         }
         else {
             /* This message dedicated to Jordan ... you big stud! */

--- a/src/act_skills.c
+++ b/src/act_skills.c
@@ -293,10 +293,10 @@ DEFINE_DO_FUN (do_groups) {
 
             printf_to_char (ch, "%-20s ", group->name);
             if (++col % 3 == 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
         }
         if (col % 3 != 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
         printf_to_char (ch, "Creation points: %d\n\r",
             ch->pcdata->creation_points);
         return;
@@ -310,10 +310,10 @@ DEFINE_DO_FUN (do_groups) {
                 break;
             printf_to_char (ch, "%-20s ", group->name);
             if (++col % 3 == 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
         }
         if (col % 3 != 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
         return;
     }
 
@@ -331,10 +331,10 @@ DEFINE_DO_FUN (do_groups) {
     for (num = 0; num < MAX_IN_GROUP && group->spells[num] != NULL; num++) {
         printf_to_char (ch, "%-20s ", group->spells[num]);
         if (++col % 3 == 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
     }
     if (col % 3 != 0)
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
 }
 
 DEFINE_DO_FUN (do_train) {
@@ -475,11 +475,11 @@ DEFINE_DO_FUN (do_practice) {
                     (3 - int_str_len (ch->pcdata->learned[sn]))),
                 ch->pcdata->learned[sn]);
             if (++col % 3 == 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
         }
 
         if (col % 3 != 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
 
         printf_to_char (ch, "You have %d practice sessions left.\n\r",
             ch->practice);
@@ -653,7 +653,7 @@ DEFINE_DO_FUN (do_cast) {
                 target = TARGET_OBJ;
             }
             else {
-                send_to_char ("You don't see that here.\n\r", ch);
+                printf_to_char (ch, "You don't see that here.\n\r");
                 return;
             }
             break;
@@ -673,7 +673,7 @@ DEFINE_DO_FUN (do_cast) {
                 target = TARGET_OBJ;
             }
             else {
-                send_to_char ("You don't see that here.\n\r", ch);
+                printf_to_char (ch, "You don't see that here.\n\r");
                 return;
             }
             break;
@@ -693,7 +693,7 @@ DEFINE_DO_FUN (do_cast) {
     WAIT_STATE (ch, skill_table[sn].beats);
 
     if (number_percent () > char_get_skill (ch, sn)) {
-        send_to_char ("You lost your concentration.\n\r", ch);
+        printf_to_char (ch, "You lost your concentration.\n\r");
         player_try_skill_improve (ch, sn, FALSE, 1);
         ch->mana -= mana / 2;
     }

--- a/src/chars.c
+++ b/src/chars.c
@@ -209,7 +209,7 @@ void char_to_room_apply_plague (CHAR_T *ch) {
             && !IS_IMMORTAL (vch) &&
             !IS_AFFECTED (vch, AFF_PLAGUE) && number_bits (6) == 0)
         {
-            send_to_char ("You feel hot and feverish.\n\r", vch);
+            printf_to_char (vch, "You feel hot and feverish.\n\r");
             act ("$n shivers and looks very ill.", vch, NULL, NULL,
                 TO_NOTCHAR);
             affect_join_char (&plague, vch);
@@ -862,7 +862,7 @@ void char_look_at_char (CHAR_T *victim, CHAR_T *ch) {
             continue;
 
         if (!found) {
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
             act ("$N is using:", ch, NULL, victim, TO_CHAR);
             found = TRUE;
         }
@@ -873,7 +873,7 @@ void char_look_at_char (CHAR_T *victim, CHAR_T *ch) {
     if (victim != ch && !IS_NPC (ch) &&
         number_percent () < char_get_skill (ch, SN(PEEK)))
     {
-        send_to_char ("\n\rYou peek at the inventory:\n\r", ch);
+        printf_to_char (ch, "\n\rYou peek at the inventory:\n\r");
         player_try_skill_improve (ch, SN(PEEK), TRUE, 4);
         obj_list_show_to_char (victim->content_first, ch, TRUE, TRUE);
     }
@@ -892,7 +892,7 @@ void char_list_show_to_char (const CHAR_T *list, CHAR_T *ch) {
             send_to_char (char_format_to_char (rch, ch), ch);
         else if (room_is_dark (ch->in_room)
                  && IS_AFFECTED (rch, AFF_INFRARED))
-            send_to_char ("You see glowing red eyes watching YOU!\n\r", ch);
+            printf_to_char (ch, "You see glowing red eyes watching YOU!\n\r");
     }
 }
 
@@ -1061,7 +1061,7 @@ bool char_wear_obj (CHAR_T *ch, OBJ_T *obj, bool replace) {
     }
     if (locs == 0) {
         if (replace)
-            send_to_char ("You can't wear, wield, or hold that.\n\r", ch);
+            printf_to_char (ch, "You can't wear, wield, or hold that.\n\r");
         return FALSE;
     }
 
@@ -1750,7 +1750,7 @@ void char_update (CHAR_T *ch) {
             {
                 if (paf->type > 0 && skill_table[paf->type].msg_off) {
                     send_to_char (skill_table[paf->type].msg_off, ch);
-                    send_to_char ("\n\r", ch);
+                    printf_to_char (ch, "\n\r");
                 }
             }
             affect_remove (paf);
@@ -1768,7 +1768,7 @@ void char_update (CHAR_T *ch) {
         if (ch->in_room == NULL)
             return;
 
-        send_to_char ("You writhe in agony from the plague.\n\r", ch);
+        printf_to_char (ch, "You writhe in agony from the plague.\n\r");
         act ("$n writhes in agony as plague sores erupt from $s skin.",
              ch, NULL, NULL, TO_NOTCHAR);
         for (af = ch->affect_first; af; af = af->on_next)
@@ -1790,7 +1790,7 @@ void char_update (CHAR_T *ch) {
                 && !IS_IMMORTAL (vch)
                 && !IS_AFFECTED (vch, AFF_PLAGUE) && number_bits (4) == 0)
             {
-                send_to_char ("You feel hot and feverish.\n\r", vch);
+                printf_to_char (vch, "You feel hot and feverish.\n\r");
                 act ("$n shivers and looks very ill.", vch, NULL, NULL,
                      TO_NOTCHAR);
                 affect_join_char (&plague, vch);
@@ -1809,7 +1809,7 @@ void char_update (CHAR_T *ch) {
         poison = affect_find (ch->affect_first, SN(POISON));
 
         if (poison != NULL) {
-            send_to_char ("You shiver and suffer.\n\r", ch);
+            printf_to_char (ch, "You shiver and suffer.\n\r");
             act ("$n shivers and suffers.", ch, NULL, NULL, TO_NOTCHAR);
             damage_quiet (ch, ch, poison->level / 10 + 1, SN(POISON),
                     DAM_POISON);

--- a/src/chars.c
+++ b/src/chars.c
@@ -833,7 +833,7 @@ void char_look_at_char (CHAR_T *victim, CHAR_T *ch) {
     }
 
     if (victim->description[0] != '\0')
-        send_to_char (victim->description, ch);
+        printf_to_char (ch, victim->description);
     else
         act ("You see nothing special about $M.", ch, NULL, victim, TO_CHAR);
 
@@ -841,7 +841,7 @@ void char_look_at_char (CHAR_T *victim, CHAR_T *ch) {
 #ifdef BASEMUD_SHOW_POSITION_IN_LOOK
     char_format_pos_msg (buf, sizeof (buf), ch, victim, TRUE);
     if (buf[0] != '\0')
-        send_to_char (buf, ch);
+        printf_to_char (ch, buf);
 
     buf[0] = '\0';
     char_format_condition_msg (buf, sizeof (buf), ch, victim, FALSE);
@@ -850,7 +850,7 @@ void char_look_at_char (CHAR_T *victim, CHAR_T *ch) {
 #endif
 
     if (buf[0] != '\0')
-        send_to_char (buf, ch);
+        printf_to_char (ch, buf);
 
     found = FALSE;
     for (wl = 0; wl < WEAR_LOC_MAX; wl++) {
@@ -1749,7 +1749,7 @@ void char_update (CHAR_T *ch) {
                 || paf_next->type != paf->type || paf_next->duration > 0)
             {
                 if (paf->type > 0 && skill_table[paf->type].msg_off) {
-                    send_to_char (skill_table[paf->type].msg_off, ch);
+                    printf_to_char (ch, skill_table[paf->type].msg_off);
                     printf_to_char (ch, "\n\r");
                 }
             }

--- a/src/comm.c
+++ b/src/comm.c
@@ -105,7 +105,7 @@ void bust_a_prompt (CHAR_T *ch) {
     }
 
     if (IS_SET (ch->comm, COMM_AFK)) {
-        send_to_char ("{p<AFK>{x ", ch);
+        printf_to_char (ch, "{p<AFK>{x ");
         return;
     }
 
@@ -203,9 +203,9 @@ void bust_a_prompt (CHAR_T *ch) {
     *point = '\0';
     pbuff = buffer;
     colour_puts (ch, ch->desc->ansi, buf, pbuff, MAX_STRING_LENGTH);
-    send_to_char ("{p", ch);
+    printf_to_char (ch, "{p");
     write_to_buffer (ch->desc, buffer, 0);
-    send_to_char ("{x", ch);
+    printf_to_char (ch, "{x");
 
     if (ch->prefix[0] != '\0')
         write_to_buffer (ch->desc, ch->prefix, 0);
@@ -479,11 +479,11 @@ void wiznet (const char *string, CHAR_T *ch, OBJ_T *obj,
             && char_get_trust (d->character) >= min_level && d->character != ch)
         {
             if (IS_SET (d->character->wiznet, WIZ_PREFIX))
-                send_to_char ("{Z--> ", d->character);
+                printf_to_char (d->character, "{Z--> ");
             else
-                send_to_char ("{Z", d->character);
+                printf_to_char (d->character, "{Z");
             act_new (string, d->character, obj, ch, TO_CHAR, POS_DEAD);
-            send_to_char ("{x", d->character);
+            printf_to_char (d->character, "{x");
         }
     }
 }
@@ -524,7 +524,7 @@ bool position_change_send_message_to_standing (CHAR_T *ch, int from,
     switch (from) {
         case POS_SLEEPING:
             if (obj == NULL) {
-                send_to_char ("You wake and stand up.\n\r", ch);
+                printf_to_char (ch, "You wake and stand up.\n\r");
                 act ("$n wakes and stands up.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -535,7 +535,7 @@ bool position_change_send_message_to_standing (CHAR_T *ch, int from,
 
         case POS_RESTING:
             if (obj == NULL) {
-                send_to_char ("You stop resting and stand up.\n\r", ch);
+                printf_to_char (ch, "You stop resting and stand up.\n\r");
                 act ("$n stops resting and stands up.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -546,7 +546,7 @@ bool position_change_send_message_to_standing (CHAR_T *ch, int from,
 
         case POS_SITTING:
             if (obj == NULL) {
-                send_to_char ("You stop sitting and stand up.\n\r", ch);
+                printf_to_char (ch, "You stop sitting and stand up.\n\r");
                 act ("$n stops sitting and stands up.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -582,17 +582,17 @@ bool position_change_send_message_to_fighting (CHAR_T *ch, int from,
 {
     switch (from) {
         case POS_SLEEPING:
-            send_to_char ("You wake up, stand up, and fight!\n\r", ch);
+            printf_to_char (ch, "You wake up, stand up, and fight!\n\r");
             act ("$n wakes up, stands up, and fights!", ch, NULL, NULL, TO_NOTCHAR);
             return TRUE;
 
         case POS_RESTING:
-            send_to_char ("You stop resting, stand up, and fight!\n\r", ch);
+            printf_to_char (ch, "You stop resting, stand up, and fight!\n\r");
             act ("$n stops resting, stands up, and fights!", ch, NULL, NULL, TO_NOTCHAR);
             return TRUE;
 
         case POS_SITTING:
-            send_to_char ("You stand up and fight!\n\r", ch);
+            printf_to_char (ch, "You stand up and fight!\n\r");
             act ("$n stands up and fights!", ch, NULL, NULL, TO_NOTCHAR);
             return TRUE;
     }
@@ -606,7 +606,7 @@ bool position_change_send_message_to_resting (CHAR_T *ch, int from,
     switch (from) {
         case POS_SLEEPING:
             if (obj == NULL) {
-                send_to_char ("You wake up and start resting.\n\r", ch);
+                printf_to_char (ch, "You wake up and start resting.\n\r");
                 act ("$n wakes up and starts resting.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -617,7 +617,7 @@ bool position_change_send_message_to_resting (CHAR_T *ch, int from,
 
         case POS_SITTING:
             if (obj == NULL) {
-                send_to_char ("You rest.\n\r", ch);
+                printf_to_char (ch, "You rest.\n\r");
                 act ("$n rests.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -628,7 +628,7 @@ bool position_change_send_message_to_resting (CHAR_T *ch, int from,
 
         case POS_STANDING:
             if (obj == NULL) {
-                send_to_char ("You sit down and rest.\n\r", ch);
+                printf_to_char (ch, "You sit down and rest.\n\r");
                 act ("$n sits down and rests.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -647,7 +647,7 @@ bool position_change_send_message_to_sitting (CHAR_T *ch, int from,
     switch (from) {
         case POS_SLEEPING:
             if (obj == NULL) {
-                send_to_char ("You wake and sit up.\n\r", ch);
+                printf_to_char (ch, "You wake and sit up.\n\r");
                 act ("$n wakes and sits up.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -658,7 +658,7 @@ bool position_change_send_message_to_sitting (CHAR_T *ch, int from,
 
         case POS_RESTING:
             if (obj == NULL)
-                send_to_char ("You stop resting.\n\r", ch);
+                printf_to_char (ch, "You stop resting.\n\r");
             else {
                 act_new ("You sit $T $p.", ch, obj, prep, TO_CHAR, POS_DEAD);
                 act ("$n sits $T $p.", ch, obj, prep, TO_NOTCHAR);
@@ -667,7 +667,7 @@ bool position_change_send_message_to_sitting (CHAR_T *ch, int from,
 
         case POS_STANDING:
             if (obj == NULL) {
-                send_to_char ("You sit down.\n\r", ch);
+                printf_to_char (ch, "You sit down.\n\r");
                 act ("$n sits down on the ground.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -688,7 +688,7 @@ bool position_change_send_message_to_sleeping (CHAR_T *ch, int from,
         case POS_SITTING:
         case POS_STANDING:
             if (obj == NULL) {
-                send_to_char ("You lie down and go to sleep.\n\r", ch);
+                printf_to_char (ch, "You lie down and go to sleep.\n\r");
                 act ("$n lies down and goes to sleep.", ch, NULL, NULL, TO_NOTCHAR);
             }
             else {
@@ -705,8 +705,8 @@ void echo_to_char (CHAR_T *to, CHAR_T *from, const char *type,
 {
     if (char_get_trust (to) >= char_get_trust (from)) {
         send_to_char (type, to);
-        send_to_char ("> ", to);
+        printf_to_char (to, "> ");
     }
     send_to_char (msg, to);
-    send_to_char ("\n\r", to);
+    printf_to_char (to, "\n\r");
 }

--- a/src/comm.c
+++ b/src/comm.c
@@ -254,12 +254,12 @@ void page_to_char (const char *txt, CHAR_T *ch) {
     if (txt == NULL || ch == NULL || ch->desc == NULL)
         return;
     if (ch->lines == 0) {
-        send_to_char (txt, ch);
+        printf_to_char (ch, txt);
         return;
     }
 
 #if defined(macintosh)
-    send_to_char (txt, ch);
+    printf_to_char (ch, txt);
 #else
     buf[0] = '\0';
     colour_puts (ch, ch->desc->ansi, txt, buf, sizeof(buf));
@@ -463,7 +463,7 @@ void printf_to_char (CHAR_T *ch, const char *fmt, ...) {
     vsnprintf (buf, sizeof(buf), fmt, args);
     va_end (args);
 
-    send_to_char (buf, ch);
+    printf_to_char (ch, buf);
 }
 
 void wiznet (const char *string, CHAR_T *ch, OBJ_T *obj,
@@ -704,9 +704,9 @@ void echo_to_char (CHAR_T *to, CHAR_T *from, const char *type,
     const char *msg)
 {
     if (char_get_trust (to) >= char_get_trust (from)) {
-        send_to_char (type, to);
+        printf_to_char (to, type);
         printf_to_char (to, "> ");
     }
-    send_to_char (msg, to);
+    printf_to_char (to, msg);
     printf_to_char (to, "\n\r");
 }

--- a/src/descs.c
+++ b/src/descs.c
@@ -546,7 +546,7 @@ bool check_reconnect (DESCRIPTOR_T *d, char *name, bool conn) {
                 d->character = ch;
                 ch->desc = d;
                 ch->timer = 0;
-                send_to_char ("Reconnecting. Type replay to see missed tells.\n\r", ch);
+                printf_to_char (ch, "Reconnecting. Type replay to see missed tells.\n\r");
                 act ("$n has reconnected.", ch, NULL, NULL, TO_NOTCHAR);
 
                 log_f ("%s@%s reconnected.", ch->name, d->host);
@@ -557,7 +557,7 @@ bool check_reconnect (DESCRIPTOR_T *d, char *name, bool conn) {
                 /* Inform the character of a note in progress and the possbility
                  * of continuation! */
                 if (ch->pcdata->in_progress)
-                    send_to_char ("You have a note in progress. Type NWRITE to continue it.\n\r", ch);
+                    printf_to_char (ch, "You have a note in progress. Type NWRITE to continue it.\n\r");
             }
             return TRUE;
         }
@@ -690,7 +690,7 @@ void desc_substitute_alias (DESCRIPTOR_T *d, char *argument) {
     /* check for prefix */
     if (ch->prefix[0] != '\0' && str_prefix ("prefix", argument)) {
         if (strlen (ch->prefix) + strlen (argument) > MAX_INPUT_LENGTH - 2)
-            send_to_char ("Line to long, prefix not processed.\r\n", ch);
+            printf_to_char (ch, "Line to long, prefix not processed.\r\n");
         else
         {
             sprintf (prefix, "%s %s", ch->prefix, argument);

--- a/src/do_sub.c
+++ b/src/do_sub.c
@@ -70,11 +70,11 @@ void do_flag_toggle (CHAR_T *ch, int player_only, flag_t *flags,
         "NPCs can't use player flags.\n\r", ch);
 
     if (IS_SET ((*flags), flag)) {
-        send_to_char (off_msg, ch);
+        printf_to_char (ch, off_msg);
         REMOVE_BIT ((*flags), flag);
     }
     else {
-        send_to_char (on_msg, ch);
+        printf_to_char (ch, on_msg);
         SET_BIT ((*flags), flag);
     }
 }
@@ -86,11 +86,11 @@ void do_ext_flag_toggle (CHAR_T *ch, int player_only, EXT_FLAGS_T *flags,
         "NPCs can't use player flags.\n\r", ch);
 
     if (EXT_IS_SET (*flags, bit)) {
-        send_to_char (off_msg, ch);
+        printf_to_char (ch, off_msg);
         EXT_UNSET (*flags, bit);
     }
     else {
-        send_to_char (on_msg, ch);
+        printf_to_char (ch, on_msg);
         EXT_SET (*flags, bit);
     }
 }

--- a/src/effects.c
+++ b/src/effects.c
@@ -423,7 +423,7 @@ DEFINE_EFFECT_FUN (effect_shock) {
 
         /* daze and confused? */
         if (!saves_spell (level / 4 + dam / 20, victim, DAM_LIGHTNING)) {
-            send_to_char ("Your muscles stop responding.\n\r", victim);
+            printf_to_char (victim, "Your muscles stop responding.\n\r");
             DAZE_STATE (victim, UMAX (12, level / 4 + dam / 20));
         }
 

--- a/src/fight.c
+++ b/src/fight.c
@@ -460,7 +460,7 @@ bool damage_real (CHAR_T *ch, CHAR_T *victim, int dam, int dt, int dam_type,
         if (!IS_IMMORTAL (ch)) {
             OBJ_T *obj;
             obj = char_get_eq_by_wear_loc (ch, WEAR_LOC_WIELD);
-            send_to_char ("You really shouldn't cheat.\n\r", ch);
+            printf_to_char (ch, "You really shouldn't cheat.\n\r");
             if (obj != NULL)
                 obj_extract (obj);
         }
@@ -561,7 +561,7 @@ bool damage_real (CHAR_T *ch, CHAR_T *victim, int dam, int dt, int dam_type,
         switch (victim->position) {
             case POS_MORTAL:
                 act ("$n is mortally wounded, and will die soon, if not aided.", victim, NULL, NULL, TO_NOTCHAR);
-                send_to_char ("You are mortally wounded, and will die soon, if not aided.\n\r", victim);
+                printf_to_char (victim, "You are mortally wounded, and will die soon, if not aided.\n\r");
                 break;
 
             case POS_INCAP:
@@ -572,12 +572,12 @@ bool damage_real (CHAR_T *ch, CHAR_T *victim, int dam, int dt, int dam_type,
 
             case POS_STUNNED:
                 act ("$n is stunned, but will probably recover.", victim, NULL, NULL, TO_NOTCHAR);
-                send_to_char ("You are stunned, but will probably recover.\n\r", victim);
+                printf_to_char (victim, "You are stunned, but will probably recover.\n\r");
                 break;
 
             case POS_DEAD:
                 act ("{R$n is DEAD!!{x", victim, NULL, NULL, TO_NOTCHAR);
-                send_to_char ("{RYou have been KILLED!!{x\n\r\n\r", victim);
+                printf_to_char (victim, "{RYou have been KILLED!!{x\n\r\n\r");
                 break;
         }
     }
@@ -585,9 +585,9 @@ bool damage_real (CHAR_T *ch, CHAR_T *victim, int dam, int dt, int dam_type,
     /* Message for serious damage! You'd better run! */
     if (victim->position > POS_STUNNED) {
         if (dam > victim->max_hit / 4)
-            send_to_char ("{RThat really did HURT!{x\n\r", victim);
+            printf_to_char (victim, "{RThat really did HURT!{x\n\r");
         if (victim->hit < victim->max_hit / 4)
-            send_to_char ("{RYou sure are BLEEDING!{x\n\r", victim);
+            printf_to_char (victim, "{RYou sure are BLEEDING!{x\n\r");
     }
 
     /* Sleep spells and extremely wounded folks. */
@@ -845,7 +845,7 @@ void check_killer (CHAR_T *ch, CHAR_T *victim) {
     if (EXT_IS_SET (ch->ext_plr, PLR_KILLER))
         return;
 
-    send_to_char ("*** You are now a KILLER!! ***\n\r", ch);
+    printf_to_char (ch, "*** You are now a KILLER!! ***\n\r");
     EXT_SET (ch->ext_plr, PLR_KILLER);
     wiznetf (ch, NULL, WIZ_FLAGS, 0, 0,
         "$N is attempting to murder %s", victim->name);
@@ -964,19 +964,19 @@ void set_fighting_one (CHAR_T *ch, CHAR_T *victim) {
     {
         switch (victim->position) {
             case POS_SLEEPING:
-                send_to_char ("You were caught sleeping!\n\r", victim);
+                printf_to_char (victim, "You were caught sleeping!\n\r");
                 act ("$n was caught sleeping!", victim, NULL, NULL, TO_NOTCHAR);
                 daze_mult = 3;
                 break;
 
             case POS_RESTING:
-                send_to_char ("You were caught resting!\n\r", victim);
+                printf_to_char (victim, "You were caught resting!\n\r");
                 act ("$n was caught resting!", victim, NULL, NULL, TO_NOTCHAR);
                 daze_mult = 2;
                 break;
 
             case POS_SITTING:
-                send_to_char ("You were caught sitting down!\n\r", victim);
+                printf_to_char (victim, "You were caught sitting down!\n\r");
                 act ("$n was caught sitting down!", victim, NULL, NULL, TO_NOTCHAR);
                 daze_mult = 1;
                 break;
@@ -1256,12 +1256,12 @@ void group_gain (CHAR_T *ch, CHAR_T *victim) {
         /* Taken out, add it back if you want it */
 #if 0
         if (gch->level - lch->level >= 5) {
-            send_to_char ("You are too high for this group.\n\r", gch);
+            printf_to_char (gch, "You are too high for this group.\n\r");
             continue;
         }
 
         if (gch->level - lch->level <= -5) {
-            send_to_char ("You are too low for this group.\n\r", gch);
+            printf_to_char (gch, "You are too low for this group.\n\r");
             continue;
         }
 #endif

--- a/src/interp.c
+++ b/src/interp.c
@@ -484,7 +484,7 @@ void interpret (CHAR_T *ch, char *argument) {
     if (ch->position < cmd_table[cmd].position) {
         msg = interpret_pos_message (ch->position);
         if (msg != NULL)
-            send_to_char (msg, ch);
+            printf_to_char (ch, msg);
         return;
     }
 
@@ -536,7 +536,7 @@ bool check_social (CHAR_T *ch, char *command, char *argument) {
 
     /* TODO: allow a minimum position for socials? */
     while (ch->position < soc->min_pos) {
-        send_to_char (interpret_pos_message (ch->position), ch);
+        printf_to_char (ch, interpret_pos_message (ch->position));
         return TRUE;
     }
 

--- a/src/interp.c
+++ b/src/interp.c
@@ -476,7 +476,7 @@ void interpret (CHAR_T *ch, char *argument) {
             && !imc_command_hook (ch, command, argument)
 #endif
            )
-            send_to_char ("Huh?\n\r", ch);
+            printf_to_char (ch, "Huh?\n\r");
         return;
     }
 
@@ -530,7 +530,7 @@ bool check_social (CHAR_T *ch, char *command, char *argument) {
     if ((soc = social_get_by_name (command)) == NULL)
         return FALSE;
     if (!IS_NPC (ch) && IS_SET (ch->comm, COMM_NOEMOTE)) {
-        send_to_char ("You are anti-social!\n\r", ch);
+        printf_to_char (ch, "You are anti-social!\n\r");
         return TRUE;
     }
 
@@ -547,7 +547,7 @@ bool check_social (CHAR_T *ch, char *command, char *argument) {
         act (soc->others_no_arg, ch, NULL, victim, TO_NOTCHAR);
     }
     else if ((victim = find_char_same_room (ch, arg)) == NULL)
-        send_to_char ("They aren't here.\n\r", ch);
+        printf_to_char (ch, "They aren't here.\n\r");
     else if (victim == ch) {
         act_new (soc->char_auto,   ch, NULL, victim, TO_CHAR, POS_DEAD);
         act (soc->others_auto, ch, NULL, victim, TO_NOTCHAR);

--- a/src/items.c
+++ b/src/items.c
@@ -895,7 +895,7 @@ bool item_look_in (const OBJ_T *obj, CHAR_T *ch) {
     switch (obj->item_type) {
         case ITEM_DRINK_CON:
             if (obj->v.drink_con.filled <= 0)
-                send_to_char ("It is empty.\n\r", ch);
+                printf_to_char (ch, "It is empty.\n\r");
             else if (obj->v.drink_con.filled >= obj->v.drink_con.capacity) {
                 printf_to_char (ch,
                     "It's completely filled with a %s liquid.\n\r",
@@ -921,7 +921,7 @@ bool item_look_in (const OBJ_T *obj, CHAR_T *ch) {
         case ITEM_CORPSE_NPC:
         case ITEM_CORPSE_PC:
             if (IS_SET (obj->v.container.flags, CONT_CLOSED))
-                send_to_char ("It is closed.\n\r", ch);
+                printf_to_char (ch, "It is closed.\n\r");
             else {
                 act ("$p holds:", ch, obj, NULL, TO_CHAR);
                 obj_list_show_to_char (obj->content_first, ch, TRUE, TRUE);
@@ -990,7 +990,7 @@ bool item_eat_effect (OBJ_T *obj, CHAR_T *ch) {
                 AFFECT_T af;
 
                 /* The food was poisoned! */
-                send_to_char ("You choke and gag.\n\r", ch);
+                printf_to_char (ch, "You choke and gag.\n\r");
                 act ("$n chokes and gags.", ch, NULL, NULL, TO_NOTCHAR);
 
                 affect_init (&af, AFF_TO_AFFECTS, SN(POISON), number_fuzzy (
@@ -1036,7 +1036,7 @@ bool item_drink_effect (OBJ_T *obj, CHAR_T *ch) {
         AFFECT_T af;
 
         /* The drink was poisoned! */
-        send_to_char ("You choke and gag.\n\r", ch);
+        printf_to_char (ch, "You choke and gag.\n\r");
         act ("$n chokes and gags.", ch, NULL, NULL, TO_NOTCHAR);
 
         affect_init (&af, AFF_TO_AFFECTS, SN(POISON), number_fuzzy (amount),
@@ -1651,7 +1651,7 @@ bool item_play_effect (OBJ_T *obj, CHAR_T *ch, char *argument) {
             RETURN_IF (song < 0 || song >= MAX_SONGS || song_table[song].name == NULL,
                 "That song isn't available.\n\r", ch, TRUE);
 
-            send_to_char ("Coming right up.\n\r", ch);
+            printf_to_char (ch, "Coming right up.\n\r");
             if (global) {
                 music_queue_values (
                     &music_line, &music_song, music_queue,
@@ -2173,7 +2173,7 @@ bool item_index_show_values (const OBJ_INDEX_T *obj, CHAR_T *ch) {
             if (obj->v.light.duration == -1 ||
                 obj->v.light.duration == 999)
             {
-                send_to_char ("[v2] Light:  Infinite[-1]\n\r", ch);
+                printf_to_char (ch, "[v2] Light:  Infinite[-1]\n\r");
             }
             else
                 printf_to_char (ch, "[v2] Light:  [%ld]\n\r",

--- a/src/items.c
+++ b/src/items.c
@@ -964,7 +964,7 @@ bool item_examine (const OBJ_T *obj, CHAR_T *ch) {
                     "silver coins in the pile.\n\r", obj->v.money.gold,
                     obj->v.money.silver);
             }
-            send_to_char (buf, ch);
+            printf_to_char (ch, buf);
             return TRUE;
 
         case ITEM_DRINK_CON:

--- a/src/magic.c
+++ b/src/magic.c
@@ -352,5 +352,5 @@ int affect_isnt_char_affected_with_act (CHAR_T *victim, int sn, flag_t flag,
 }
 
 DEFINE_SPELL_FUN (spell_null) {
-    send_to_char ("That's not a spell!\n\r", ch);
+    printf_to_char (ch, "That's not a spell!\n\r");
 }

--- a/src/mob_cmds.c
+++ b/src/mob_cmds.c
@@ -149,9 +149,9 @@ DEFINE_DO_FUN (do_mpgecho) {
     for (d = descriptor_first; d; d = d->global_next) {
         if (d->connected == CON_PLAYING) {
             if (IS_IMMORTAL (d->character))
-                send_to_char ("Mob echo> ", d->character);
+                printf_to_char (d->character, "Mob echo> ");
             send_to_char (argument, d->character);
-            send_to_char ("\n\r", d->character);
+            printf_to_char (d->character, "\n\r");
         }
     }
 }
@@ -173,9 +173,9 @@ DEFINE_DO_FUN (do_mpzecho) {
             && d->character->in_room->area == ch->in_room->area)
         {
             if (IS_IMMORTAL (d->character))
-                send_to_char ("Mob echo> ", d->character);
+                printf_to_char (d->character, "Mob echo> ");
             send_to_char (argument, d->character);
-            send_to_char ("\n\r", d->character);
+            printf_to_char (d->character, "\n\r");
         }
     }
 }

--- a/src/mob_cmds.c
+++ b/src/mob_cmds.c
@@ -150,7 +150,7 @@ DEFINE_DO_FUN (do_mpgecho) {
         if (d->connected == CON_PLAYING) {
             if (IS_IMMORTAL (d->character))
                 printf_to_char (d->character, "Mob echo> ");
-            send_to_char (argument, d->character);
+            printf_to_char (d->character, argument);
             printf_to_char (d->character, "\n\r");
         }
     }
@@ -174,7 +174,7 @@ DEFINE_DO_FUN (do_mpzecho) {
         {
             if (IS_IMMORTAL (d->character))
                 printf_to_char (d->character, "Mob echo> ");
-            send_to_char (argument, d->character);
+            printf_to_char (d->character, argument);
             printf_to_char (d->character, "\n\r");
         }
     }

--- a/src/nanny.c
+++ b/src/nanny.c
@@ -683,7 +683,7 @@ DEFINE_NANNY_FUN (nanny_gen_groups) {
     }
 
     if (nanny_parse_gen_groups (ch, argument))
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
     do_function (ch, &do_help, "menu choice");
 }
 
@@ -710,7 +710,7 @@ bool nanny_parse_gen_groups (CHAR_T *ch, char *argument) {
 
     if (!str_prefix (arg, "add")) {
         if (argument[0] == '\0') {
-            send_to_char ("You must provide a skill name.\n\r", ch);
+            printf_to_char (ch, "You must provide a skill name.\n\r");
             return TRUE;
         }
 
@@ -718,17 +718,17 @@ bool nanny_parse_gen_groups (CHAR_T *ch, char *argument) {
         if (num != -1) {
             group = skill_group_get (num);
             if (ch->gen_data->group_chosen[num] || ch->pcdata->group_known[num]) {
-                send_to_char ("You already know that group!\n\r", ch);
+                printf_to_char (ch, "You already know that group!\n\r");
                 return TRUE;
             }
             if (group->classes[ch->class].cost < 1) {
-                send_to_char ("That group is not available.\n\r", ch);
+                printf_to_char (ch, "That group is not available.\n\r");
                 return TRUE;
             }
 
             /* Close security hole */
             if (ch->pcdata->creation_points + group->classes[ch->class].cost > 300) {
-                send_to_char ("You cannot take more than 300 creation points.\n\r", ch);
+                printf_to_char (ch, "You cannot take more than 300 creation points.\n\r");
                 return TRUE;
             }
 
@@ -744,17 +744,17 @@ bool nanny_parse_gen_groups (CHAR_T *ch, char *argument) {
             if (ch->gen_data->skill_chosen[num] || ch->pcdata->skill_known[num] > 0 ||
                 ch->pcdata->learned[num] > 0)
             {
-                send_to_char ("You already know that skill!\n\r", ch);
+                printf_to_char (ch, "You already know that skill!\n\r");
                 return TRUE;
             }
             if (skill->classes[ch->class].effort < 1 || skill->spell_fun != spell_null) {
-                send_to_char ("That skill is not available.\n\r", ch);
+                printf_to_char (ch, "That skill is not available.\n\r");
                 return TRUE;
             }
 
             /* Close security hole */
             if (ch->pcdata->creation_points + skill->classes[ch->class].effort > 300) {
-                send_to_char ("You cannot take more than 300 creation points.\n\r", ch);
+                printf_to_char (ch, "You cannot take more than 300 creation points.\n\r");
                 return TRUE;
             }
 
@@ -764,13 +764,13 @@ bool nanny_parse_gen_groups (CHAR_T *ch, char *argument) {
             return TRUE;
         }
 
-        send_to_char ("No skills or groups by that name...\n\r", ch);
+        printf_to_char (ch, "No skills or groups by that name...\n\r");
         return TRUE;
     }
 
     if (!strcmp (arg, "drop")) {
         if (argument[0] == '\0') {
-            send_to_char ("You must provide a skill to drop.\n\r", ch);
+            printf_to_char (ch, "You must provide a skill to drop.\n\r");
             return TRUE;
         }
 
@@ -792,7 +792,7 @@ bool nanny_parse_gen_groups (CHAR_T *ch, char *argument) {
             return TRUE;
         }
 
-        send_to_char ("You haven't bought any such skill or group.\n\r", ch);
+        printf_to_char (ch, "You haven't bought any such skill or group.\n\r");
         return TRUE;
     }
 
@@ -828,7 +828,7 @@ DEFINE_NANNY_FUN (nanny_gen_groups_done) {
 
     pc_race = pc_race_get_by_race (ch->race);
     if (ch->pcdata->creation_points == pc_race->creation_points) {
-        send_to_char ("You didn't pick anything.\n\r\n\r", ch);
+        printf_to_char (ch, "You didn't pick anything.\n\r\n\r");
         do_function (ch, &do_help, "menu choice");
         return;
     }
@@ -915,9 +915,9 @@ DEFINE_NANNY_FUN (nanny_read_motd) {
         obj_give_to_char (obj_create (obj_get_index (OBJ_VNUM_MAP), 0), ch);
 
         char_to_room (ch, room_get_index (ROOM_VNUM_SCHOOL));
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
         do_function (ch, &do_help, "newbie info");
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
     }
     else if (ch->in_room != NULL)
         char_to_room (ch, ch->in_room);

--- a/src/objs.c
+++ b/src/objs.c
@@ -570,8 +570,8 @@ void obj_list_show_to_char (const OBJ_T *list, CHAR_T *ch, bool is_short,
 
     if (show_nothing && show_string_num == 0) {
         if (IS_NPC (ch) || IS_SET (ch->comm, COMM_COMBINE))
-            send_to_char ("     ", ch);
-        send_to_char ("Nothing.\n\r", ch);
+            printf_to_char (ch, "     ");
+        printf_to_char (ch, "Nothing.\n\r");
     }
     page_to_char (buf_string (output), ch);
 

--- a/src/olc.c
+++ b/src/olc.c
@@ -322,7 +322,7 @@ bool show_commands (CHAR_T *ch, char *argument) {
  Called by:    aedit, redit, oedit, medit(olc.c)
  ****************************************************************************/
 bool edit_done (CHAR_T *ch) {
-    send_to_char ("Exiting OLC.\n\r", ch);
+    printf_to_char (ch, "Exiting OLC.\n\r");
     ch->desc->olc_edit = NULL;
     ch->desc->editor = 0;
     return FALSE;
@@ -346,7 +346,7 @@ void aedit (CHAR_T *ch, char *argument) {
     argument = one_argument (argument, command);
 
     if (!IS_BUILDER (ch, area)) {
-        send_to_char ("AEdit:  Insufficient security to modify area.\n\r", ch);
+        printf_to_char (ch, "AEdit:  Insufficient security to modify area.\n\r");
         edit_done (ch);
         return;
     }
@@ -360,7 +360,7 @@ void aedit (CHAR_T *ch, char *argument) {
     }
     if ((value = flags_from_string_exact (area_flags, command)) != FLAG_NONE) {
         TOGGLE_BIT (area->area_flags, value);
-        send_to_char ("Flag toggled.\n\r", ch);
+        printf_to_char (ch, "Flag toggled.\n\r");
         return;
     }
 
@@ -396,7 +396,7 @@ void redit (CHAR_T *ch, char *argument) {
     argument = one_argument (argument, command);
 
     if (!IS_BUILDER (ch, area)) {
-        send_to_char ("REdit:  Insufficient security to modify room.\n\r", ch);
+        printf_to_char (ch, "REdit:  Insufficient security to modify room.\n\r");
         edit_done (ch);
         return;
     }
@@ -441,7 +441,7 @@ void oedit (CHAR_T *ch, char *argument) {
     area = obj->area;
 
     if (!IS_BUILDER (ch, area)) {
-        send_to_char ("OEdit: Insufficient security to modify area.\n\r", ch);
+        printf_to_char (ch, "OEdit: Insufficient security to modify area.\n\r");
         edit_done (ch);
         return;
     }
@@ -486,7 +486,7 @@ void medit (CHAR_T *ch, char *argument) {
     area = mob->area;
 
     if (!IS_BUILDER (ch, area)) {
-        send_to_char ("MEdit: Insufficient security to modify area.\n\r", ch);
+        printf_to_char (ch, "MEdit: Insufficient security to modify area.\n\r");
         edit_done (ch);
         return;
     }
@@ -582,7 +582,7 @@ void hedit (CHAR_T *ch, char *argument) {
         return;
     }
     if (ch->pcdata->security < 9) {
-        send_to_char ("HEdit: Insufficient security to edit helps.\n\r", ch);
+        printf_to_char (ch, "HEdit: Insufficient security to edit helps.\n\r");
         edit_done (ch);
         return;
     }
@@ -608,13 +608,13 @@ void hedit (CHAR_T *ch, char *argument) {
 
 bool show_version (CHAR_T *ch, char *argument) {
     send_to_char (OLC_VERSION, ch);
-    send_to_char ("\n\r", ch);
+    printf_to_char (ch, "\n\r");
     send_to_char (OLC_AUTHOR, ch);
-    send_to_char ("\n\r", ch);
+    printf_to_char (ch, "\n\r");
     send_to_char (OLC_DATE, ch);
-    send_to_char ("\n\r", ch);
+    printf_to_char (ch, "\n\r");
     send_to_char (OLC_CREDITS, ch);
-    send_to_char ("\n\r", ch);
+    printf_to_char (ch, "\n\r");
     return FALSE;
 }
 
@@ -756,7 +756,7 @@ void show_spec_cmds (CHAR_T *ch) {
 
     buf1[0] = '\0';
     col = 0;
-    send_to_char ("Preceed special functions with 'spec_'\n\r\n\r", ch);
+    printf_to_char (ch, "Preceed special functions with 'spec_'\n\r\n\r");
     for (spec = 0; spec_table[spec].function != NULL; spec++) {
         sprintf (buf, "%-19.18s", &spec_table[spec].name[5]);
         strcat (buf1, buf);
@@ -785,8 +785,8 @@ bool show_help (CHAR_T *ch, char *argument) {
 
     /* Display syntax.  */
     if (arg[0] == '\0') {
-        send_to_char ("Syntax:  ? [command]\n\r\n\r", ch);
-        send_to_char ("[command]          [description]\n\r", ch);
+        printf_to_char (ch, "Syntax:  ? [command]\n\r\n\r");
+        printf_to_char (ch, "[command]          [description]\n\r");
         for (cnt = 0; master_table[cnt].table != NULL; cnt++)
             printf_to_char (ch, "%-18.18s -%s\n\r",
                 master_table[cnt].name, master_table[cnt].description);

--- a/src/olc.c
+++ b/src/olc.c
@@ -296,7 +296,7 @@ void show_olc_cmds (CHAR_T *ch, const struct olc_cmd_type *olc_table) {
     if (col % 5 != 0)
         strcat (buf1, "\n\r");
 
-    send_to_char (buf1, ch);
+    printf_to_char (ch, buf1);
 }
 
 /*****************************************************************************
@@ -607,13 +607,13 @@ void hedit (CHAR_T *ch, char *argument) {
 }
 
 bool show_version (CHAR_T *ch, char *argument) {
-    send_to_char (OLC_VERSION, ch);
+    printf_to_char (ch, OLC_VERSION);
     printf_to_char (ch, "\n\r");
-    send_to_char (OLC_AUTHOR, ch);
+    printf_to_char (ch, OLC_AUTHOR);
     printf_to_char (ch, "\n\r");
-    send_to_char (OLC_DATE, ch);
+    printf_to_char (ch, OLC_DATE);
     printf_to_char (ch, "\n\r");
-    send_to_char (OLC_CREDITS, ch);
+    printf_to_char (ch, OLC_CREDITS);
     printf_to_char (ch, "\n\r");
     return FALSE;
 }
@@ -684,7 +684,7 @@ void show_flag_cmds (CHAR_T *ch, const FLAG_T *flag_table) {
     if (col % 4 != 0)
         strcat (buf1, "\n\r");
 
-    send_to_char (buf1, ch);
+    printf_to_char (ch, buf1);
 }
 
 void show_type_cmds (CHAR_T *ch, const TYPE_T *type_table) {
@@ -705,7 +705,7 @@ void show_type_cmds (CHAR_T *ch, const TYPE_T *type_table) {
     if (col % 4 != 0)
         strcat (buf1, "\n\r");
 
-    send_to_char (buf1, ch);
+    printf_to_char (ch, buf1);
 }
 
 /*****************************************************************************
@@ -740,7 +740,7 @@ void show_skill_cmds (CHAR_T *ch, int tar) {
 
     if (col % 4 != 0)
         strcat (buf1, "\n\r");
-    send_to_char (buf1, ch);
+    printf_to_char (ch, buf1);
 }
 
 /*****************************************************************************
@@ -767,7 +767,7 @@ void show_spec_cmds (CHAR_T *ch) {
     if (col % 4 != 0)
         strcat (buf1, "\n\r");
 
-    send_to_char (buf1, ch);
+    printf_to_char (ch, buf1);
 }
 
 /*****************************************************************************
@@ -863,7 +863,7 @@ bool olc_str_replace_dup (CHAR_T *ch, char **old_str, char *new_str,
     RETURN_IF (new_str == NULL || new_str[0] == '\0',
         syntax_msg, ch, FALSE);
     str_replace_dup (old_str, new_str);
-    send_to_char (success_msg, ch);
+    printf_to_char (ch, success_msg);
     return TRUE;
 }
 
@@ -876,7 +876,7 @@ bool olc_int_replace (CHAR_T *ch, int *old_val, char *new_val,
     RETURN_IF (buf == NULL || buf[0] == '\0' || !is_number (buf),
         syntax_msg, ch, FALSE);
     *old_val = atoi (buf);
-    send_to_char (success_msg, ch);
+    printf_to_char (ch, success_msg);
     return TRUE;
 }
 
@@ -889,7 +889,7 @@ bool olc_sh_int_replace (CHAR_T *ch, sh_int *old_val, char *new_val,
     RETURN_IF (buf == NULL || buf[0] == '\0' || !is_number (buf),
         syntax_msg, ch, FALSE);
     *old_val = atoi (buf);
-    send_to_char (success_msg, ch);
+    printf_to_char (ch, success_msg);
     return TRUE;
 }
 
@@ -902,6 +902,6 @@ bool olc_long_int_replace (CHAR_T *ch, long int *old_val, char *new_val,
     RETURN_IF (buf == NULL || buf[0] == '\0' || !is_number (buf),
         syntax_msg, ch, FALSE);
     *old_val = atol (buf);
-    send_to_char (success_msg, ch);
+    printf_to_char (ch, success_msg);
     return TRUE;
 }

--- a/src/olc_aedit.c
+++ b/src/olc_aedit.c
@@ -80,7 +80,7 @@ AEDIT (aedit_reset) {
     EDIT_AREA (ch, area);
 
     area_reset (area);
-    send_to_char ("Area reset.\n\r", ch);
+    printf_to_char (ch, "Area reset.\n\r");
     return FALSE;
 }
 
@@ -92,7 +92,7 @@ AEDIT (aedit_create) {
     ch->desc->olc_edit = (void *) area;
 
     SET_BIT (area->area_flags, AREA_ADDED);
-    send_to_char ("Area created.\n\r", ch);
+    printf_to_char (ch, "Area created.\n\r");
     return FALSE;
 }
 
@@ -136,7 +136,7 @@ AEDIT (aedit_file) {
     str_replace_dup (&(area->name), file);
     strcat (file, ".are");
     str_replace_dup (&(area->filename), file);
-    send_to_char ("Filename set.\n\r", ch);
+    printf_to_char (ch, "Filename set.\n\r");
     return TRUE;
 }
 
@@ -157,18 +157,18 @@ AEDIT (aedit_recall) {
     one_argument (argument, room);
 
     if (!is_number (argument) || argument[0] == '\0') {
-        send_to_char ("Syntax:  recall [#xrvnum]\n\r", ch);
+        printf_to_char (ch, "Syntax:  recall [#xrvnum]\n\r");
         return FALSE;
     }
 
     value = atoi (room);
     if (!room_get_index (value)) {
-        send_to_char ("AEdit:  Room vnum does not exist.\n\r", ch);
+        printf_to_char (ch, "AEdit:  Room vnum does not exist.\n\r");
         return FALSE;
     }
 
     area->recall = value;
-    send_to_char ("Recall set.\n\r", ch);
+    printf_to_char (ch, "Recall set.\n\r");
     return TRUE;
 }
 #endif /* ROM OLC */
@@ -189,12 +189,12 @@ AEDIT (aedit_security) {
         if (ch->pcdata->security != 0)
             printf_to_char (ch, "Security is 0-%d.\n\r", ch->pcdata->security);
         else
-            send_to_char ("Security is 0 only.\n\r", ch);
+            printf_to_char (ch, "Security is 0 only.\n\r");
         return FALSE;
     }
 
     area->security = value;
-    send_to_char ("Security set.\n\r", ch);
+    printf_to_char (ch, "Security set.\n\r");
     return TRUE;
 }
 
@@ -217,7 +217,7 @@ AEDIT (aedit_builder) {
 
         if (area->builders[0] == '\0')
             str_replace_dup (&(area->builders), "None");
-        send_to_char ("Builder removed.\n\r", ch);
+        printf_to_char (ch, "Builder removed.\n\r");
         return TRUE;
     }
     else {
@@ -268,7 +268,7 @@ AEDIT (aedit_vnum) {
         "AEdit: Lower vnum already assigned.\n\r", ch, FALSE);
 
     area->min_vnum = ilower;
-    send_to_char ("Lower vnum set.\n\r", ch);
+    printf_to_char (ch, "Lower vnum set.\n\r");
 
     other = area_get_by_inner_vnum (iupper);
     RETURN_IF (other && other != area,
@@ -276,7 +276,7 @@ AEDIT (aedit_vnum) {
                         /* The lower value has been set ^^^^ */
 
     area->max_vnum = iupper;
-    send_to_char ("Upper vnum set.\n\r", ch);
+    printf_to_char (ch, "Upper vnum set.\n\r");
     return TRUE;
 }
 
@@ -302,7 +302,7 @@ AEDIT (aedit_lvnum) {
         "AEdit: Lower vnum already assigned.\n\r", ch, FALSE);
 
     area->min_vnum = ilower;
-    send_to_char ("Lower vnum set.\n\r", ch);
+    printf_to_char (ch, "Lower vnum set.\n\r");
     return TRUE;
 }
 
@@ -327,6 +327,6 @@ AEDIT (aedit_uvnum) {
         "AEdit: Upper vnum already assigned.\n\r", ch, FALSE);
 
     area->max_vnum = iupper;
-    send_to_char ("Upper vnum set.\n\r", ch);
+    printf_to_char (ch, "Upper vnum set.\n\r");
     return TRUE;
 }

--- a/src/olc_hedit.c
+++ b/src/olc_hedit.c
@@ -116,7 +116,7 @@ HEDIT (hedit_new) {
     ch->desc->olc_edit = (HELP_T *) help;
     ch->desc->editor = ED_HELP;
 
-    send_to_char ("Help created.\n\r", ch);
+    printf_to_char (ch, "Help created.\n\r");
     return FALSE;
 }
 
@@ -158,7 +158,7 @@ HEDIT (hedit_delete) {
         "HEdit delete: Help %s not found in had_list.", help->keyword);
     help_free (help);
 
-    send_to_char ("Help deleted.\n\r", ch);
+    printf_to_char (ch, "Help deleted.\n\r");
     return TRUE;
 }
 

--- a/src/olc_medit.c
+++ b/src/olc_medit.c
@@ -117,8 +117,8 @@ MEDIT (medit_show) {
             if (shop->buy_type[trade] == 0)
                 continue;
             if (trade == 0) {
-                send_to_char ("  Number Trades Type\n\r", ch);
-                send_to_char ("  ------ -----------\n\r", ch);
+                printf_to_char (ch, "  Number Trades Type\n\r");
+                printf_to_char (ch, "  ------ -----------\n\r");
             }
             printf_to_char (ch, "  [%4d] %s\n\r", trade,
                 item_get_name (shop->buy_type[trade]));
@@ -131,8 +131,8 @@ MEDIT (medit_show) {
         printf_to_char (ch, "\n\rMOBPrograms for [%5d]:\n\r", mob->vnum);
         for (cnt = 0, list = mob->mprog_first; list; list = list->mob_next) {
             if (cnt == 0) {
-                send_to_char (" Number Vnum Trigger Phrase\n\r", ch);
-                send_to_char (" ------ ---- ------- ------\n\r", ch);
+                printf_to_char (ch, " Number Vnum Trigger Phrase\n\r");
+                printf_to_char (ch, " ------ ---- ------- ------\n\r");
             }
 
             printf_to_char (ch, "[%5d] %4d %7s %s\n\r", cnt,
@@ -175,7 +175,7 @@ MEDIT (medit_create) {
 
     db_finalize_mob (mob);
 
-    send_to_char ("Mobile created.\n\r", ch);
+    printf_to_char (ch, "Mobile created.\n\r");
     return TRUE;
 }
 
@@ -188,16 +188,16 @@ MEDIT (medit_spec) {
 
     if (!str_cmp (argument, "none")) {
         mob->spec_fun = NULL;
-        send_to_char ("Spec removed.\n\r", ch);
+        printf_to_char (ch, "Spec removed.\n\r");
         return TRUE;
     }
     else if (spec_lookup (argument) >= 0) {
         mob->spec_fun = spec_lookup_function (argument);
-        send_to_char ("Spec set.\n\r", ch);
+        printf_to_char (ch, "Spec set.\n\r");
         return TRUE;
     }
 
-    send_to_char ("MEdit: No such special function.\n\r", ch);
+    printf_to_char (ch, "MEdit: No such special function.\n\r");
     return FALSE;
 }
 
@@ -210,7 +210,7 @@ MEDIT (medit_damtype) {
         "For a list of damage types, type '? weapon'.\n\r", ch, FALSE);
 
     mob->attack_type = attack_lookup (argument);
-    send_to_char ("Damage type set.\n\r", ch);
+    printf_to_char (ch, "Damage type set.\n\r");
     return TRUE;
 }
 
@@ -238,7 +238,7 @@ MEDIT (medit_desc) {
         string_append (ch, &mob->description);
         return TRUE;
     }
-    send_to_char ("Syntax: desc    - line edit\n\r", ch);
+    printf_to_char (ch, "Syntax: desc    - line edit\n\r");
     return FALSE;
 }
 
@@ -253,7 +253,7 @@ MEDIT (medit_long) {
     argument[0] = UPPER (argument[0]);
     str_replace_dup (&(mob->long_descr), argument);
 
-    send_to_char ("Long description set.\n\r", ch);
+    printf_to_char (ch, "Long description set.\n\r");
     return TRUE;
 }
 
@@ -300,7 +300,7 @@ MEDIT (medit_shop) {
         mob->shop->open_hour  = atoi (arg1);
         mob->shop->close_hour = atoi (argument);
 
-        send_to_char ("Shop hours set.\n\r", ch);
+        printf_to_char (ch, "Shop hours set.\n\r");
         return TRUE;
     }
 
@@ -314,7 +314,7 @@ MEDIT (medit_shop) {
         mob->shop->profit_buy = atoi (arg1);
         mob->shop->profit_sell = atoi (argument);
 
-        send_to_char ("Shop profit set.\n\r", ch);
+        printf_to_char (ch, "Shop profit set.\n\r");
         return TRUE;
     }
 
@@ -333,7 +333,7 @@ MEDIT (medit_shop) {
             "MEdit: That type of item is not known.\n\r", ch, FALSE);
         mob->shop->buy_type[atoi (arg1)] = value;
 
-        send_to_char ("Shop type set.\n\r", ch);
+        printf_to_char (ch, "Shop type set.\n\r");
         return TRUE;
     }
 
@@ -346,7 +346,7 @@ MEDIT (medit_shop) {
         LIST2_BACK (mob->shop, global_prev, global_next, shop_first, shop_last);
         mob->shop->keeper = mob->vnum;
 
-        send_to_char ("New shop assigned to mobile.\n\r", ch);
+        printf_to_char (ch, "New shop assigned to mobile.\n\r");
         return TRUE;
     }
 
@@ -355,7 +355,7 @@ MEDIT (medit_shop) {
         shop_free (mob->shop);
         mob->shop = NULL;
 
-        send_to_char ("Mobile is no longer a shopkeeper.\n\r", ch);
+        printf_to_char (ch, "Mobile is no longer a shopkeeper.\n\r");
         return TRUE;
     }
 
@@ -373,7 +373,7 @@ MEDIT (medit_sex) {
         EDIT_MOB (ch, mob);
         if ((value = type_lookup (sex_types, argument)) != TYPE_NONE) {
             mob->sex = value;
-            send_to_char ("Sex set.\n\r", ch);
+            printf_to_char (ch, "Sex set.\n\r");
             return TRUE;
         }
     }
@@ -421,7 +421,7 @@ MEDIT (medit_act) {
             EXT_SET (mob->ext_mob_final, MOB_IS_NPC);
             UPDATE_EXT_FLAGS (mob, ext_mob, ext_mob);
 
-            send_to_char ("Mob flag toggled.\n\r", ch);
+            printf_to_char (ch, "Mob flag toggled.\n\r");
             return TRUE;
         }
     }
@@ -441,7 +441,7 @@ MEDIT (medit_affect) {
             TOGGLE_BIT (mob->affected_by_final, value);
             UPDATE_FLAGS (mob, affected_by, aff);
 
-            send_to_char ("Affect flag toggled.\n\r", ch);
+            printf_to_char (ch, "Affect flag toggled.\n\r");
             return TRUE;
         }
     }
@@ -498,7 +498,7 @@ MEDIT (medit_ac) {
         mob->ac[AC_SLASH]  = slash;
         mob->ac[AC_EXOTIC] = exotic;
 
-        send_to_char ("Ac set.\n\r", ch);
+        printf_to_char (ch, "Ac set.\n\r");
         return TRUE;
     }
     while (FALSE); /* Just do it once.. */
@@ -519,7 +519,7 @@ MEDIT (medit_form) {
             TOGGLE_BIT (mob->form_plus, value);
             UPDATE_FLAGS (mob, form, form);
 
-            send_to_char ("Form toggled.\n\r", ch);
+            printf_to_char (ch, "Form toggled.\n\r");
             return TRUE;
         }
     }
@@ -538,7 +538,7 @@ MEDIT (medit_part) {
             TOGGLE_BIT (mob->parts_plus, value);
             UPDATE_FLAGS (mob, parts, parts);
 
-            send_to_char ("Parts toggled.\n\r", ch);
+            printf_to_char (ch, "Parts toggled.\n\r");
             return TRUE;
         }
     }
@@ -557,7 +557,7 @@ MEDIT (medit_imm) {
             TOGGLE_BIT (mob->imm_flags_plus, value);
             UPDATE_FLAGS (mob, imm_flags, imm);
 
-            send_to_char ("Immunity toggled.\n\r", ch);
+            printf_to_char (ch, "Immunity toggled.\n\r");
             return TRUE;
         }
     }
@@ -576,7 +576,7 @@ MEDIT (medit_res) {
             TOGGLE_BIT (mob->res_flags_plus, value);
             UPDATE_FLAGS (mob, res_flags, res);
 
-            send_to_char ("Resistance toggled.\n\r", ch);
+            printf_to_char (ch, "Resistance toggled.\n\r");
             return TRUE;
         }
     }
@@ -595,7 +595,7 @@ MEDIT (medit_vuln) {
             TOGGLE_BIT (mob->vuln_flags_plus, value);
             UPDATE_FLAGS (mob, vuln_flags, vuln);
 
-            send_to_char ("Vulnerability toggled.\n\r", ch);
+            printf_to_char (ch, "Vulnerability toggled.\n\r");
             return TRUE;
         }
     }
@@ -612,11 +612,11 @@ MEDIT (medit_material) {
         EDIT_MOB (ch, mob);
         if ((mat = material_get_by_name (argument)) != NULL) {
             mob->material = mat->type;
-            send_to_char ("Material type changed.\n\r", ch);
+            printf_to_char (ch, "Material type changed.\n\r");
             return TRUE;
         }
     }
-    send_to_char ("Syntax: material [type]\n\r", ch);
+    printf_to_char (ch, "Syntax: material [type]\n\r");
     return FALSE;
 }
 
@@ -630,7 +630,7 @@ MEDIT (medit_off) {
             TOGGLE_BIT (mob->off_flags_plus, value);
             UPDATE_FLAGS (mob, off_flags, off);
 
-            send_to_char ("Offensive behaviour toggled.\n\r", ch);
+            printf_to_char (ch, "Offensive behaviour toggled.\n\r");
             return TRUE;
         }
     }
@@ -647,7 +647,7 @@ MEDIT (medit_size) {
         EDIT_MOB (ch, mob);
         if ((value = type_lookup (size_types, argument)) != TYPE_NONE) {
             mob->size = value;
-            send_to_char ("Size set.\n\r", ch);
+            printf_to_char (ch, "Size set.\n\r");
             return TRUE;
         }
     }
@@ -692,7 +692,7 @@ MEDIT (medit_hitdice) {
     mob->hit.size   = atoi (type);
     mob->hit.bonus  = atoi (bonus);
 
-    send_to_char ("Hitdice set.\n\r", ch);
+    printf_to_char (ch, "Hitdice set.\n\r");
     return TRUE;
 }
 
@@ -735,7 +735,7 @@ MEDIT (medit_manadice) {
     mob->mana.size   = atoi (type);
     mob->mana.bonus  = atoi (bonus);
 
-    send_to_char ("Manadice set.\n\r", ch);
+    printf_to_char (ch, "Manadice set.\n\r");
     return TRUE;
 }
 
@@ -779,7 +779,7 @@ MEDIT (medit_damdice) {
     mob->damage.size   = atoi (type);
     mob->damage.bonus  = atoi (bonus);
 
-    send_to_char ("Damdice set.\n\r", ch);
+    printf_to_char (ch, "Damdice set.\n\r");
     return TRUE;
 }
 
@@ -793,22 +793,22 @@ MEDIT (medit_race) {
         mob->race = i;
         db_finalize_mob (mob);
 
-        send_to_char ("Race set.\n\r", ch);
+        printf_to_char (ch, "Race set.\n\r");
         return TRUE;
     }
 
     if (argument[0] == '?') {
-        send_to_char ("Available races are:", ch);
+        printf_to_char (ch, "Available races are:");
 
         for (i = 0; i < RACE_MAX; i++) {
             if ((race = race_get (i)) == NULL)
                 break;
             if ((i % 3) == 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
             printf_to_char (ch, " %-15s", race->name);
         }
 
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
         return FALSE;
     }
     send_to_char ("Syntax: race [race]\n\r"
@@ -835,7 +835,7 @@ MEDIT (medit_position) {
 
             EDIT_MOB (ch, mob);
             mob->start_pos = value;
-            send_to_char ("Start position set.\n\r", ch);
+            printf_to_char (ch, "Start position set.\n\r");
             return TRUE;
 
         case 'D':
@@ -847,7 +847,7 @@ MEDIT (medit_position) {
 
             EDIT_MOB (ch, mob);
             mob->default_pos = value;
-            send_to_char ("Default position set.\n\r", ch);
+            printf_to_char (ch, "Default position set.\n\r");
             return TRUE;
     }
 
@@ -888,7 +888,7 @@ MEDIT (medit_group) {
 
     if (is_number (argument)) {
         mob->group = atoi (argument);
-        send_to_char ("Group set.\n\r", ch);
+        printf_to_char (ch, "Group set.\n\r");
         return TRUE;
     }
 
@@ -910,7 +910,7 @@ MEDIT (medit_group) {
         if (found)
             page_to_char (buf_string (buffer), ch);
         else
-            send_to_char ("No mobs in that group.\n\r", ch);
+            printf_to_char (ch, "No mobs in that group.\n\r");
 
         buf_free (buffer);
         return FALSE;
@@ -942,7 +942,7 @@ MEDIT (medit_addmprog) {
         "MEdit: That vnum is not assigned an area.\n\r", ch, FALSE);
 
     if ((value = flags_from_string (mprog_flags, trigger)) == FLAG_NONE) {
-        send_to_char ("Valid flags are:\n\r", ch);
+        printf_to_char (ch, "Valid flags are:\n\r");
         show_help (ch, "mprog");
         return FALSE;
     }
@@ -959,7 +959,7 @@ MEDIT (medit_addmprog) {
     SET_BIT (mob->mprog_flags, value);
     LIST2_FRONT (list, mob_prev, mob_next, mob->mprog_first, mob->mprog_last);
 
-    send_to_char ("Mob program created.\n\r", ch);
+    printf_to_char (ch, "Mob program created.\n\r");
     return TRUE;
 }
 
@@ -990,6 +990,6 @@ MEDIT (medit_delmprog) {
     REMOVE_BIT (mob->mprog_flags, mplist->trig_type);
     mprog_free (mplist);
 
-    send_to_char ("Mob program removed.\n\r", ch);
+    printf_to_char (ch, "Mob program removed.\n\r");
     return TRUE;
 }

--- a/src/olc_mpedit.c
+++ b/src/olc_mpedit.c
@@ -52,7 +52,7 @@ MPEDIT (mpedit_create) {
     ch->desc->olc_edit = (void *) mcode;
     ch->desc->editor = ED_MPCODE;
 
-    send_to_char ("Mob program created.\n\r", ch);
+    printf_to_char (ch, "Mob program created.\n\r");
     return TRUE;
 }
 
@@ -75,7 +75,7 @@ MPEDIT (mpedit_code) {
         return TRUE;
     }
 
-    send_to_char ("Syntax: code\n\r", ch);
+    printf_to_char (ch, "Syntax: code\n\r");
     return FALSE;
 }
 

--- a/src/olc_oedit.c
+++ b/src/olc_oedit.c
@@ -47,7 +47,7 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_LIGHT");
                     return FALSE;
                 case 2:
-                    send_to_char ("HOURS OF LIGHT SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "HOURS OF LIGHT SET.\n\r\n\r");
                     obj->v.value[2] = atoi (argument);
                     break;
             }
@@ -60,19 +60,19 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_STAFF_WAND");
                     return FALSE;
                 case 0:
-                    send_to_char ("SPELL LEVEL SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "SPELL LEVEL SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("TOTAL NUMBER OF CHARGES SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "TOTAL NUMBER OF CHARGES SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
                 case 2:
-                    send_to_char ("CURRENT NUMBER OF CHARGES SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "CURRENT NUMBER OF CHARGES SET.\n\r\n\r");
                     obj->v.value[2] = atoi (argument);
                     break;
                 case 3:
-                    send_to_char ("SPELL TYPE SET.\n\r", ch);
+                    printf_to_char (ch, "SPELL TYPE SET.\n\r");
                     obj->v.value[3] = skill_lookup (argument);
                     break;
             }
@@ -86,23 +86,23 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_SCROLL_POTION_PILL");
                     return FALSE;
                 case 0:
-                    send_to_char ("SPELL LEVEL SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "SPELL LEVEL SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("SPELL TYPE 1 SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "SPELL TYPE 1 SET.\n\r\n\r");
                     obj->v.value[1] = skill_lookup (argument);
                     break;
                 case 2:
-                    send_to_char ("SPELL TYPE 2 SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "SPELL TYPE 2 SET.\n\r\n\r");
                     obj->v.value[2] = skill_lookup (argument);
                     break;
                 case 3:
-                    send_to_char ("SPELL TYPE 3 SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "SPELL TYPE 3 SET.\n\r\n\r");
                     obj->v.value[3] = skill_lookup (argument);
                     break;
                 case 4:
-                    send_to_char ("SPELL TYPE 4 SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "SPELL TYPE 4 SET.\n\r\n\r");
                     obj->v.value[4] = skill_lookup (argument);
                     break;
             }
@@ -115,19 +115,19 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_ARMOR");
                     return FALSE;
                 case 0:
-                    send_to_char ("AC PIERCE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "AC PIERCE SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("AC BASH SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "AC BASH SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
                 case 2:
-                    send_to_char ("AC SLASH SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "AC SLASH SET.\n\r\n\r");
                     obj->v.value[2] = atoi (argument);
                     break;
                 case 3:
-                    send_to_char ("AC EXOTIC SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "AC EXOTIC SET.\n\r\n\r");
                     obj->v.value[3] = atoi (argument);
                     break;
             }
@@ -140,24 +140,24 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_WEAPON");
                     return FALSE;
                 case 0:
-                    send_to_char ("WEAPON CLASS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "WEAPON CLASS SET.\n\r\n\r");
                     ALT_TYPEVALUE_SET (obj->v.value[0], weapon_types,
                                        argument);
                     break;
                 case 1:
-                    send_to_char ("NUMBER OF DICE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "NUMBER OF DICE SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
                 case 2:
-                    send_to_char ("TYPE OF DICE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "TYPE OF DICE SET.\n\r\n\r");
                     obj->v.value[2] = atoi (argument);
                     break;
                 case 3:
-                    send_to_char ("WEAPON TYPE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "WEAPON TYPE SET.\n\r\n\r");
                     obj->v.value[3] = attack_lookup (argument);
                     break;
                 case 4:
-                    send_to_char ("SPECIAL WEAPON TYPE TOGGLED.\n\r\n\r", ch);
+                    printf_to_char (ch, "SPECIAL WEAPON TYPE TOGGLED.\n\r\n\r");
                     ALT_FLAGVALUE_TOGGLE (obj->v.value[4], weapon_flags,
                                           argument);
                     break;
@@ -170,19 +170,19 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_PORTAL");
                     return FALSE;
                 case 0:
-                    send_to_char ("CHARGES SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "CHARGES SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("EXIT FLAGS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "EXIT FLAGS SET.\n\r\n\r");
                     ALT_FLAGVALUE_SET (obj->v.value[1], exit_flags, argument);
                     break;
                 case 2:
-                    send_to_char ("PORTAL FLAGS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "PORTAL FLAGS SET.\n\r\n\r");
                     ALT_FLAGVALUE_SET (obj->v.value[2], gate_flags, argument);
                     break;
                 case 3:
-                    send_to_char ("EXIT VNUM SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "EXIT VNUM SET.\n\r\n\r");
                     obj->v.value[3] = atoi (argument);
                     break;
             }
@@ -194,23 +194,23 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_FURNITURE");
                     return FALSE;
                 case 0:
-                    send_to_char ("NUMBER OF PEOPLE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "NUMBER OF PEOPLE SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("MAX WEIGHT SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "MAX WEIGHT SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
                 case 2:
-                    send_to_char ("FURNITURE FLAGS TOGGLED.\n\r\n\r", ch);
+                    printf_to_char (ch, "FURNITURE FLAGS TOGGLED.\n\r\n\r");
                     ALT_FLAGVALUE_TOGGLE (obj->v.value[2], furniture_flags, argument);
                     break;
                 case 3:
-                    send_to_char ("HEAL BONUS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "HEAL BONUS SET.\n\r\n\r");
                     obj->v.value[3] = atoi (argument);
                     break;
                 case 4:
-                    send_to_char ("MANA BONUS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "MANA BONUS SET.\n\r\n\r");
                     obj->v.value[4] = atoi (argument);
                     break;
             }
@@ -223,7 +223,7 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_CONTAINER");
                     return FALSE;
                 case 0:
-                    send_to_char ("WEIGHT CAPACITY SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "WEIGHT CAPACITY SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
@@ -233,28 +233,28 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                         do_help (ch, "ITEM_CONTAINER");
                         return FALSE;
                     }
-                    send_to_char ("CONTAINER TYPE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "CONTAINER TYPE SET.\n\r\n\r");
                     break;
                 case 2:
                     if (atoi (argument) != 0) {
                         if (!obj_get_index (atoi (argument))) {
-                            send_to_char ("THERE IS NO SUCH ITEM.\n\r\n\r", ch);
+                            printf_to_char (ch, "THERE IS NO SUCH ITEM.\n\r\n\r");
                             return FALSE;
                         }
                         if (obj_get_index (atoi (argument))->item_type != ITEM_KEY) {
-                            send_to_char ("THAT ITEM IS NOT A KEY.\n\r\n\r", ch);
+                            printf_to_char (ch, "THAT ITEM IS NOT A KEY.\n\r\n\r");
                             return FALSE;
                         }
                     }
-                    send_to_char ("CONTAINER KEY SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "CONTAINER KEY SET.\n\r\n\r");
                     obj->v.value[2] = atoi (argument);
                     break;
                 case 3:
-                    send_to_char ("CONTAINER MAX WEIGHT SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "CONTAINER MAX WEIGHT SET.\n\r\n\r");
                     obj->v.value[3] = atoi (argument);
                     break;
                 case 4:
-                    send_to_char ("WEIGHT MULTIPLIER SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "WEIGHT MULTIPLIER SET.\n\r\n\r");
                     obj->v.value[4] = atoi (argument);
                     break;
             }
@@ -267,20 +267,20 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
 /* OLC              do_help (ch, "liquids"); */
                     return FALSE;
                 case 0:
-                    send_to_char ("MAXIMUM AMOUT OF LIQUID HOURS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "MAXIMUM AMOUT OF LIQUID HOURS SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("CURRENT AMOUNT OF LIQUID HOURS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "CURRENT AMOUNT OF LIQUID HOURS SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
                 case 2:
-                    send_to_char ("LIQUID TYPE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "LIQUID TYPE SET.\n\r\n\r");
                     obj->v.value[2] = (liq_lookup (argument) >= 0 ?
                                       liq_lookup (argument) : 0);
                     break;
                 case 3:
-                    send_to_char ("POISON VALUE TOGGLED.\n\r\n\r", ch);
+                    printf_to_char (ch, "POISON VALUE TOGGLED.\n\r\n\r");
                     obj->v.value[3] = (obj->v.value[3] == 0) ? 1 : 0;
                     break;
             }
@@ -293,15 +293,15 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
 /* OLC              do_help (ch, "liquids"); */
                     return FALSE;
                 case 0:
-                    send_to_char ("MAXIMUM AMOUT OF LIQUID HOURS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "MAXIMUM AMOUT OF LIQUID HOURS SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("CURRENT AMOUNT OF LIQUID HOURS SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "CURRENT AMOUNT OF LIQUID HOURS SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
                 case 2:
-                    send_to_char ("LIQUID TYPE SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "LIQUID TYPE SET.\n\r\n\r");
                     obj->v.value[2] = (liq_lookup (argument) >= 0 ?
                                         liq_lookup (argument) : 0);
                     break;
@@ -314,15 +314,15 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_FOOD");
                     return FALSE;
                 case 0:
-                    send_to_char ("HOURS OF FOOD SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "HOURS OF FOOD SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("HOURS OF FULL SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "HOURS OF FULL SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
                 case 3:
-                    send_to_char ("POISON VALUE TOGGLED.\n\r\n\r", ch);
+                    printf_to_char (ch, "POISON VALUE TOGGLED.\n\r\n\r");
                     obj->v.value[3] = (obj->v.value[3] == 0) ? 1 : 0;
                     break;
             }
@@ -334,11 +334,11 @@ bool oedit_set_obj_values (CHAR_T *ch, OBJ_INDEX_T *obj,
                     do_help (ch, "ITEM_MONEY");
                     return FALSE;
                 case 0:
-                    send_to_char ("GOLD AMOUNT SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "GOLD AMOUNT SET.\n\r\n\r");
                     obj->v.value[0] = atoi (argument);
                     break;
                 case 1:
-                    send_to_char ("SILVER AMOUNT SET.\n\r\n\r", ch);
+                    printf_to_char (ch, "SILVER AMOUNT SET.\n\r\n\r");
                     obj->v.value[1] = atoi (argument);
                     break;
             }
@@ -404,11 +404,11 @@ OEDIT (oedit_show) {
 
     if (obj->extra_descr_first) {
         EXTRA_DESCR_T *ed;
-        send_to_char ("Ex desc kwd:", ch);
+        printf_to_char (ch, "Ex desc kwd:");
 
         for (ed = obj->extra_descr_first; ed; ed = ed->on_next)
             printf_to_char (ch, " [%s]", ed->keyword);
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
     }
 
     printf_to_char (ch, "Short desc:  %s\n\rLong desc:\n\r     %s\n\r",
@@ -447,7 +447,7 @@ OEDIT (oedit_addaffect) {
         "Syntax: addaffect [location] [#xmod]\n\r", ch, FALSE);
 
     if ((value = type_lookup (affect_apply_types, loc)) == TYPE_NONE) { /* Hugin */
-        send_to_char ("Valid affects are:\n\r", ch);
+        printf_to_char (ch, "Valid affects are:\n\r");
         show_help (ch, "apply");
         return FALSE;
     }
@@ -456,7 +456,7 @@ OEDIT (oedit_addaffect) {
     affect_init (aff, AFF_TO_OBJECT, -1, obj->level, -1, value, atoi (mod), 0);
     affect_to_obj_index_back (aff, obj);
 
-    send_to_char ("Affect added.\n\r", ch);
+    printf_to_char (ch, "Affect added.\n\r");
     return TRUE;
 }
 
@@ -479,14 +479,14 @@ OEDIT (oedit_addapply) {
     one_argument (argument, bit_buf);
 
     if (mod[0] == '\0' || !is_number (mod)) {
-        send_to_char ("Syntax: addapply [bit_type] [apply] [#xmod] [bit]\n\r", ch);
+        printf_to_char (ch, "Syntax: addapply [bit_type] [apply] [#xmod] [bit]\n\r");
         return FALSE;
     }
 
     if (bit_type_buf[0] == '\0' ||
         (bit_type_obj = affect_bit_get_by_name (bit_type_buf)) == NULL)
     {
-        send_to_char ("Invalid bit type. Valid bit types are:\n\r", ch);
+        printf_to_char (ch, "Invalid bit type. Valid bit types are:\n\r");
         show_help (ch, "affect_bit_table");
         return FALSE;
     }
@@ -495,7 +495,7 @@ OEDIT (oedit_addapply) {
     if (app_buf[0] == '\0' ||
         (app = type_lookup (affect_apply_types, app_buf)) == TYPE_NONE)
     {
-        send_to_char ("Invalid apply type. Valid apply types are:\n\r", ch);
+        printf_to_char (ch, "Invalid apply type. Valid apply types are:\n\r");
         show_help (ch, "affect_apply_types");
         return FALSE;
     }
@@ -503,8 +503,8 @@ OEDIT (oedit_addapply) {
     if (bit_buf[0] == '\0' ||
         (bit = flags_from_string (bit_type_obj->flags, bit_buf)) == FLAG_NONE)
     {
-        send_to_char ("Invalid bit. Valid bits are: \n\r", ch);
-        send_to_char ("Valid flag types are:\n\r", ch);
+        printf_to_char (ch, "Invalid bit. Valid bits are: \n\r");
+        printf_to_char (ch, "Valid flag types are:\n\r");
         show_help (ch, bit_type_obj->help);
         return FALSE;
     }
@@ -513,7 +513,7 @@ OEDIT (oedit_addapply) {
     affect_init (aff, bit_type, -1, obj->level, -1, app, atoi (mod), bit);
     affect_to_obj_index_back (aff, obj);
 
-    send_to_char ("Apply added.\n\r", ch);
+    printf_to_char (ch, "Apply added.\n\r");
     return TRUE;
 }
 
@@ -530,24 +530,24 @@ OEDIT (oedit_delaffect) {
     one_argument (argument, affect);
 
     if (!is_number (affect) || affect[0] == '\0') {
-        send_to_char ("Syntax: delaffect [#xaffect]\n\r", ch);
+        printf_to_char (ch, "Syntax: delaffect [#xaffect]\n\r");
         return FALSE;
     }
     value = atoi (affect);
     if (value < 0) {
-        send_to_char ("Only non-negative affect-numbers allowed.\n\r", ch);
+        printf_to_char (ch, "Only non-negative affect-numbers allowed.\n\r");
         return FALSE;
     }
 
     /* Find the affect and its previous link in the list. */
     LIST_FIND (value >= cnt++, on_next, obj->affect_first, aff);
     if (!aff) {
-        send_to_char ("OEdit: Non-existant affect.\n\r", ch);
+        printf_to_char (ch, "OEdit: Non-existant affect.\n\r");
         return FALSE;
     }
 
     affect_free (aff);
-    send_to_char ("Affect removed.\n\r", ch);
+    printf_to_char (ch, "Affect removed.\n\r");
     return TRUE;
 }
 
@@ -556,13 +556,13 @@ OEDIT (oedit_name) {
     EDIT_OBJ (ch, obj);
 
     if (argument[0] == '\0') {
-        send_to_char ("Syntax: name [string]\n\r", ch);
+        printf_to_char (ch, "Syntax: name [string]\n\r");
         return FALSE;
     }
 
     str_replace_dup (&(obj->name), argument);
 
-    send_to_char ("Name set.\n\r", ch);
+    printf_to_char (ch, "Name set.\n\r");
     return TRUE;
 }
 
@@ -571,14 +571,14 @@ OEDIT (oedit_short) {
     EDIT_OBJ (ch, obj);
 
     if (argument[0] == '\0') {
-        send_to_char ("Syntax: short [string]\n\r", ch);
+        printf_to_char (ch, "Syntax: short [string]\n\r");
         return FALSE;
     }
 
     str_replace_dup (&(obj->short_descr), argument);
     obj->short_descr[0] = LOWER (obj->short_descr[0]);
 
-    send_to_char ("Short description set.\n\r", ch);
+    printf_to_char (ch, "Short description set.\n\r");
     return TRUE;
 }
 
@@ -587,14 +587,14 @@ OEDIT (oedit_long) {
     EDIT_OBJ (ch, obj);
 
     if (argument[0] == '\0') {
-        send_to_char ("Syntax: long [string]\n\r", ch);
+        printf_to_char (ch, "Syntax: long [string]\n\r");
         return FALSE;
     }
 
     str_replace_dup (&(obj->description), argument);
     obj->description[0] = UPPER (obj->description[0]);
 
-    send_to_char ("Long description set.\n\r", ch);
+    printf_to_char (ch, "Long description set.\n\r");
     return TRUE;
 }
 
@@ -614,12 +614,12 @@ OEDIT (oedit_weight) {
     EDIT_OBJ (ch, obj);
 
     if (argument[0] == '\0' || !is_number (argument)) {
-        send_to_char ("Syntax: weight [number]\n\r", ch);
+        printf_to_char (ch, "Syntax: weight [number]\n\r");
         return FALSE;
     }
     obj->weight = atoi (argument);
 
-    send_to_char ("Weight set.\n\r", ch);
+    printf_to_char (ch, "Weight set.\n\r");
     return TRUE;
 }
 
@@ -628,12 +628,12 @@ OEDIT (oedit_cost) {
     EDIT_OBJ (ch, obj);
 
     if (argument[0] == '\0' || !is_number (argument)) {
-        send_to_char ("Syntax: cost [number]\n\r", ch);
+        printf_to_char (ch, "Syntax: cost [number]\n\r");
         return FALSE;
     }
     obj->cost = atoi (argument);
 
-    send_to_char ("Cost set.\n\r", ch);
+    printf_to_char (ch, "Cost set.\n\r");
     return TRUE;
 }
 
@@ -644,21 +644,21 @@ OEDIT (oedit_create) {
 
     value = atoi (argument);
     if (argument[0] == '\0' || value == 0) {
-        send_to_char ("Syntax: oedit create [vnum]\n\r", ch);
+        printf_to_char (ch, "Syntax: oedit create [vnum]\n\r");
         return FALSE;
     }
 
     area = area_get_by_inner_vnum (value);
     if (!area) {
-        send_to_char ("OEdit: That vnum is not assigned an area.\n\r", ch);
+        printf_to_char (ch, "OEdit: That vnum is not assigned an area.\n\r");
         return FALSE;
     }
     if (!IS_BUILDER (ch, area)) {
-        send_to_char ("OEdit: Vnum in an area you cannot build in.\n\r", ch);
+        printf_to_char (ch, "OEdit: Vnum in an area you cannot build in.\n\r");
         return FALSE;
     }
     if (obj_get_index (value)) {
-        send_to_char ("OEdit: Object vnum already exists.\n\r", ch);
+        printf_to_char (ch, "OEdit: Object vnum already exists.\n\r");
         return FALSE;
     }
 
@@ -673,7 +673,7 @@ OEDIT (oedit_create) {
     obj_index_to_hash (obj);
     ch->desc->olc_edit = (void *) obj;
 
-    send_to_char ("Object created.\n\r", ch);
+    printf_to_char (ch, "Object created.\n\r");
     return TRUE;
 }
 
@@ -689,15 +689,15 @@ OEDIT (oedit_ed) {
     one_argument (argument, keyword);
 
     if (command[0] == '\0') {
-        send_to_char ("Syntax: ed add [keyword]\n\r", ch);
-        send_to_char ("        ed delete [keyword]\n\r", ch);
-        send_to_char ("        ed edit [keyword]\n\r", ch);
-        send_to_char ("        ed format [keyword]\n\r", ch);
+        printf_to_char (ch, "Syntax: ed add [keyword]\n\r");
+        printf_to_char (ch, "        ed delete [keyword]\n\r");
+        printf_to_char (ch, "        ed edit [keyword]\n\r");
+        printf_to_char (ch, "        ed format [keyword]\n\r");
         return FALSE;
     }
     if (!str_cmp (command, "add")) {
         if (keyword[0] == '\0') {
-            send_to_char ("Syntax: ed add [keyword]\n\r", ch);
+            printf_to_char (ch, "Syntax: ed add [keyword]\n\r");
             return FALSE;
         }
         ed = extra_descr_new ();
@@ -710,13 +710,13 @@ OEDIT (oedit_ed) {
 
     if (!str_cmp (command, "edit")) {
         if (keyword[0] == '\0') {
-            send_to_char ("Syntax: ed edit [keyword]\n\r", ch);
+            printf_to_char (ch, "Syntax: ed edit [keyword]\n\r");
             return FALSE;
         }
         LIST_FIND (str_in_namelist (keyword, ed->keyword), on_next,
             obj->extra_descr_first, ed);
         if (!ed) {
-            send_to_char ("OEdit: Extra description keyword not found.\n\r", ch);
+            printf_to_char (ch, "OEdit: Extra description keyword not found.\n\r");
             return FALSE;
         }
 
@@ -726,35 +726,35 @@ OEDIT (oedit_ed) {
 
     if (!str_cmp (command, "delete")) {
         if (keyword[0] == '\0') {
-            send_to_char ("Syntax: ed delete [keyword]\n\r", ch);
+            printf_to_char (ch, "Syntax: ed delete [keyword]\n\r");
             return FALSE;
         }
         LIST_FIND (str_in_namelist (keyword, ed->keyword), on_next,
             obj->extra_descr_first, ed);
         if (!ed) {
-            send_to_char ("OEdit: Extra description keyword not found.\n\r", ch);
+            printf_to_char (ch, "OEdit: Extra description keyword not found.\n\r");
             return FALSE;
         }
 
         extra_descr_free (ed);
-        send_to_char ("Extra description deleted.\n\r", ch);
+        printf_to_char (ch, "Extra description deleted.\n\r");
         return TRUE;
     }
 
     if (!str_cmp (command, "format")) {
         if (keyword[0] == '\0') {
-            send_to_char ("Syntax: ed format [keyword]\n\r", ch);
+            printf_to_char (ch, "Syntax: ed format [keyword]\n\r");
             return FALSE;
         }
         LIST_FIND (str_in_namelist (keyword, ed->keyword), on_next,
             obj->extra_descr_first, ed);
         if (!ed) {
-            send_to_char ("OEdit: Extra description keyword not found.\n\r", ch);
+            printf_to_char (ch, "OEdit: Extra description keyword not found.\n\r");
             return FALSE;
         }
 
         ed->description = format_string (ed->description);
-        send_to_char ("Extra description formatted.\n\r", ch);
+        printf_to_char (ch, "Extra description formatted.\n\r");
         return TRUE;
     }
 
@@ -772,7 +772,7 @@ OEDIT (oedit_extra) {
         EDIT_OBJ (ch, obj);
         if ((value = flags_from_string (extra_flags, argument)) != FLAG_NONE) {
             TOGGLE_BIT (obj->extra_flags, value);
-            send_to_char ("Extra flag toggled.\n\r", ch);
+            printf_to_char (ch, "Extra flag toggled.\n\r");
             return TRUE;
         }
     }
@@ -791,7 +791,7 @@ OEDIT (oedit_wear) {
         EDIT_OBJ (ch, obj);
         if ((value = flags_from_string (wear_flags, argument)) != FLAG_NONE) {
             TOGGLE_BIT (obj->wear_flags, value);
-            send_to_char ("Wear flag toggled.\n\r", ch);
+            printf_to_char (ch, "Wear flag toggled.\n\r");
             return TRUE;
         }
     }
@@ -810,7 +810,7 @@ OEDIT (oedit_type) {
         EDIT_OBJ (ch, obj);
         if ((value = item_lookup (argument)) >= 0) {
             obj->item_type = value;
-            send_to_char ("Type set.\n\r", ch);
+            printf_to_char (ch, "Type set.\n\r");
             for (i = 0; i < OBJ_VALUE_MAX; i++)
                 obj->v.value[i] = 0;
             return TRUE;
@@ -830,12 +830,12 @@ OEDIT (oedit_material) {
         EDIT_OBJ (ch, obj);
         if ((mat = material_get_by_name (argument)) != NULL) {
             obj->material = mat->type;
-            send_to_char ("Material type changed.\n\r", ch);
+            printf_to_char (ch, "Material type changed.\n\r");
             return TRUE;
         }
     }
 
-    send_to_char ("Syntax: material [type]\n\r", ch);
+    printf_to_char (ch, "Syntax: material [type]\n\r");
     return FALSE;
 }
 
@@ -844,12 +844,12 @@ OEDIT (oedit_level) {
     EDIT_OBJ (ch, obj);
 
     if (argument[0] == '\0' || !is_number (argument)) {
-        send_to_char ("Syntax: level [number]\n\r", ch);
+        printf_to_char (ch, "Syntax: level [number]\n\r");
         return FALSE;
     }
     obj->level = atoi (argument);
 
-    send_to_char ("Level set.\n\r", ch);
+    printf_to_char (ch, "Level set.\n\r");
     return TRUE;
 }
 
@@ -862,7 +862,7 @@ OEDIT (oedit_condition) {
     {
         EDIT_OBJ (ch, obj);
         obj->condition = value;
-        send_to_char ("Condition set.\n\r", ch);
+        printf_to_char (ch, "Condition set.\n\r");
         return TRUE;
     }
 

--- a/src/olc_redit.c
+++ b/src/olc_redit.c
@@ -71,7 +71,7 @@ bool redit_change_exit (CHAR_T *ch, char *argument, int door) {
             rev_ex->rs_flags   = ex->rs_flags;
         }
 
-        send_to_char ("Exit flag toggled.\n\r", ch);
+        printf_to_char (ch, "Exit flag toggled.\n\r");
         return TRUE;
     }
 
@@ -112,10 +112,10 @@ bool redit_change_exit (CHAR_T *ch, char *argument, int door) {
 
         /* Unlink our exit. */
         exit_to_room_index_to (ex, NULL);
-        send_to_char ("Exit unlinked.\n\r", ch);
+        printf_to_char (ch, "Exit unlinked.\n\r");
         if (rev_ex) {
             exit_to_room_index_to (rev_ex, NULL);
-            send_to_char ("Reverse exit unlinked.\n\r", ch);
+            printf_to_char (ch, "Reverse exit unlinked.\n\r");
         }
 
         /* Update portals if necessary. */
@@ -164,7 +164,7 @@ bool redit_change_exit (CHAR_T *ch, char *argument, int door) {
         exit_to_room_index_to (rev_ex, room);
 
         /* Update portals if necessary. */
-        send_to_char ("Two-way link established.\n\r", ch);
+        printf_to_char (ch, "Two-way link established.\n\r");
         redit_change_exit_update_portals (ex, old_room, old_rev_room, ch);
 
         return TRUE;
@@ -198,7 +198,7 @@ bool redit_change_exit (CHAR_T *ch, char *argument, int door) {
 
         old_room = ex->to_room;
         exit_to_room_index_to (ex, to_room);
-        send_to_char ("One-way link established.\n\r", ch);
+        printf_to_char (ch, "One-way link established.\n\r");
 
         /* Update portals if necessary. */
         redit_change_exit_update_portals (ex, old_room, NULL, ch);
@@ -222,7 +222,7 @@ bool redit_change_exit (CHAR_T *ch, char *argument, int door) {
             "REdit: Object is not a key.\n\r", ch, FALSE);
 
         ex->key = value;
-        send_to_char ("Exit key set.\n\r", ch);
+        printf_to_char (ch, "Exit key set.\n\r");
         return TRUE;
     }
 
@@ -240,7 +240,7 @@ bool redit_change_exit (CHAR_T *ch, char *argument, int door) {
         else
             str_replace_dup (&ex->keyword, arg);
 
-        send_to_char ("Exit name set.\n\r", ch);
+        printf_to_char (ch, "Exit name set.\n\r");
         return TRUE;
     }
 
@@ -273,14 +273,14 @@ bool redit_change_exit (CHAR_T *ch, char *argument, int door) {
         if (ex->portal) {
             RETURN_IF (!portal_exit_rename (ex->portal, arg),
                 "The portal exit could not be renamed.\n\r", ch, FALSE);
-            send_to_char ("Portal renamed.\n\r", ch);
+            printf_to_char (ch, "Portal renamed.\n\r");
             return TRUE;
         }
         else {
             PORTAL_EXIT_T *pex;
             pex = portal_exit_create (arg);
             portal_exit_to_exit (pex, ex);
-            send_to_char ("Portal created.\n\r", ch);
+            printf_to_char (ch, "Portal created.\n\r");
             return TRUE;
         }
     }
@@ -866,7 +866,7 @@ REDIT (redit_ed) {
             "REdit: Extra description keyword not found.\n\r", ch, FALSE);
 
         extra_descr_free (ed);
-        send_to_char ("Extra description deleted.\n\r", ch);
+        printf_to_char (ch, "Extra description deleted.\n\r");
         return TRUE;
     }
 
@@ -879,7 +879,7 @@ REDIT (redit_ed) {
             "REdit: Extra description keyword not found.\n\r", ch, FALSE);
 
         ed->description = format_string (ed->description);
-        send_to_char ("Extra description formatted.\n\r", ch);
+        printf_to_char (ch, "Extra description formatted.\n\r");
         return TRUE;
     }
 
@@ -915,7 +915,7 @@ REDIT (redit_create) {
 
     ch->desc->olc_edit = (void *) room;
 
-    send_to_char ("Room created.\n\r", ch);
+    printf_to_char (ch, "Room created.\n\r");
     return TRUE;
 }
 
@@ -927,7 +927,7 @@ REDIT (redit_name) {
         "Syntax: name [name]\n\r", ch, FALSE);
 
     str_replace_dup (&(room->name), argument);
-    send_to_char ("Name set.\n\r", ch);
+    printf_to_char (ch, "Name set.\n\r");
     return TRUE;
 }
 
@@ -950,7 +950,7 @@ REDIT (redit_heal) {
         "Syntax: heal <#xnumber>\n\r", ch, FALSE);
 
     room->heal_rate = atoi (argument);
-    send_to_char ("Heal rate set.\n\r", ch);
+    printf_to_char (ch, "Heal rate set.\n\r");
     return TRUE;
 }
 
@@ -962,7 +962,7 @@ REDIT (redit_mana) {
         "Syntax: mana <#xnumber>\n\r", ch, FALSE);
 
     room->mana_rate = atoi (argument);
-    send_to_char ("Mana rate set.\n\r", ch);
+    printf_to_char (ch, "Mana rate set.\n\r");
     return TRUE;
 }
 
@@ -972,7 +972,7 @@ REDIT (redit_clan) {
 
     /* TODO: Show an error if the clan doesn't exist */
     room->clan = clan_lookup (argument);
-    send_to_char ("Clan set.\n\r", ch);
+    printf_to_char (ch, "Clan set.\n\r");
     return TRUE;
 }
 
@@ -981,7 +981,7 @@ REDIT (redit_format) {
     EDIT_ROOM (ch, room);
 
     room->description = format_string (room->description);
-    send_to_char ("String formatted.\n\r", ch);
+    printf_to_char (ch, "String formatted.\n\r");
     return TRUE;
 }
 
@@ -1175,7 +1175,7 @@ REDIT (redit_oreset) {
     }
     /* Display Syntax */
     else {
-        send_to_char ("REdit: That mobile isn't here.\n\r", ch);
+        printf_to_char (ch, "REdit: That mobile isn't here.\n\r");
         return FALSE;
     }
 
@@ -1196,7 +1196,7 @@ REDIT (redit_owner) {
     else
         str_replace_dup (&room->owner, argument);
 
-    send_to_char ("Owner set.\n\r", ch);
+    printf_to_char (ch, "Owner set.\n\r");
     return TRUE;
 }
 
@@ -1210,7 +1210,7 @@ REDIT (redit_room) {
         "Syntax: room [flags]\n\r", ch, FALSE);
 
     TOGGLE_BIT (room->room_flags, value);
-    send_to_char ("Room flags toggled.\n\r", ch);
+    printf_to_char (ch, "Room flags toggled.\n\r");
     return TRUE;
 }
 
@@ -1224,7 +1224,7 @@ REDIT (redit_sector) {
         "Syntax: sector [type]\n\r", ch, FALSE);
 
     room->sector_type = value;
-    send_to_char ("Sector type set.\n\r", ch);
+    printf_to_char (ch, "Sector type set.\n\r");
     return TRUE;
 }
 
@@ -1242,14 +1242,14 @@ REDIT (redit_portal) {
     if (room->portal) {
         RETURN_IF (!portal_exit_rename (room->portal, argument),
             "The portal exit could not be renamed.\n\r", ch, FALSE);
-        send_to_char ("Portal renamed.\n\r", ch);
+        printf_to_char (ch, "Portal renamed.\n\r");
         return TRUE;
     }
     else {
         PORTAL_EXIT_T *pex;
         pex = portal_exit_create (argument);
         portal_exit_to_room (pex, room);
-        send_to_char ("Portal created.\n\r", ch);
+        printf_to_char (ch, "Portal created.\n\r");
         return TRUE;
     }
 }

--- a/src/olc_redit.c
+++ b/src/olc_redit.c
@@ -798,7 +798,7 @@ REDIT (redit_show) {
         }
     }
 
-    send_to_char (buf1, ch);
+    printf_to_char (ch, buf1);
     return FALSE;
 }
 

--- a/src/players.c
+++ b/src/players.c
@@ -777,7 +777,7 @@ void player_change_condition (CHAR_T *ch, int cond, int value) {
 
     /* if there's a message, send it over. */
     if (msg)
-        send_to_char (msg, ch);
+        printf_to_char (ch, msg);
 }
 
 void player_update (CHAR_T *ch) {

--- a/src/players.c
+++ b/src/players.c
@@ -263,7 +263,7 @@ void player_gain_exp (CHAR_T *ch, int gain) {
     while (ch->level < LEVEL_HERO && ch->exp >=
            player_get_exp_per_level (ch) * (ch->level + 1))
     {
-        send_to_char ("{GYou raise a level!!  {x", ch);
+        printf_to_char (ch, "{GYou raise a level!!  {x");
         ch->level += 1;
         log_f ("%s gained level %d", ch->name, ch->level);
         wiznetf (ch, NULL, WIZ_LEVELS, 0, 0,
@@ -359,19 +359,19 @@ void player_list_skills_and_groups (CHAR_T *ch, bool chosen) {
             continue;
 
         if (col % 3 == 0)
-            send_to_char ("   ", ch);
+            printf_to_char (ch, "   ");
         printf_to_char (ch, "%s%s%d  ", group->name,
             str_line (LINE_CHAR, 19 - strlen (group->name) +
                 (3 - int_str_len (group->classes[ch->class].cost))),
             group->classes[ch->class].cost);
         if (++col % 3 == 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
     }
     if (col == 0)
-        send_to_char ("   None.\n\r", ch);
+        printf_to_char (ch, "   None.\n\r");
     if (col % 3 != 0)
-        send_to_char ("\n\r", ch);
-    send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
+    printf_to_char (ch, "\n\r");
 
     col = 0;
     printf_to_char (ch, "Skills:\n\r");
@@ -390,23 +390,23 @@ void player_list_skills_and_groups (CHAR_T *ch, bool chosen) {
             continue;
 
         if (col % 3 == 0)
-            send_to_char ("   ", ch);
+            printf_to_char (ch, "   ");
 
         printf_to_char (ch, "%s%s%d  ", skill->name,
             str_line (LINE_CHAR, 19 - strlen (skill->name) +
                 (3 - int_str_len (skill->classes[ch->class].effort))),
             skill->classes[ch->class].effort);
         if (++col % 3 == 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
     }
     if (col == 0)
-        send_to_char ("   None.\n\r", ch);
+        printf_to_char (ch, "   None.\n\r");
     if (col % 3 != 0)
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
 
     /* only show generation points during character generation. */
     if (ch->gen_data) {
-        send_to_char ("\n\r", ch);
+        printf_to_char (ch, "\n\r");
         printf_to_char (ch, "Creation points: %d\n\r",
             ch->pcdata->creation_points);
         printf_to_char (ch, "Experience per level: %d\n\r",
@@ -799,7 +799,7 @@ void player_update (CHAR_T *ch) {
             ch->was_in_room = ch->in_room;
             if (ch->fighting != NULL)
                 stop_fighting (ch, TRUE);
-            send_to_char ("You disappear into the void.\n\r", ch);
+            printf_to_char (ch, "You disappear into the void.\n\r");
             act ("$n disappears into the void.",
                  ch, NULL, NULL, TO_NOTCHAR);
             if (ch->level > 1)

--- a/src/special.c
+++ b/src/special.c
@@ -184,7 +184,7 @@ bool spec_patrolman (CHAR_T *ch) {
 
             if (vch->in_room != ch->in_room
                 && vch->in_room->area == ch->in_room->area)
-                send_to_char ("You hear a shrill whistling sound.\n\r", vch);
+                printf_to_char (vch, "You hear a shrill whistling sound.\n\r");
         }
     }
 

--- a/src/spell_aff.c
+++ b/src/spell_aff.c
@@ -52,7 +52,7 @@ DEFINE_SPELL_FUN (spell_armor) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, 24, APPLY_AC, -20, 0);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel someone protecting you.\n\r", victim);
+    printf_to_char (victim, "You feel someone protecting you.\n\r");
     if (ch != victim)
         act ("$N is protected by your magic.", ch, NULL, victim, TO_CHAR);
 }
@@ -103,7 +103,7 @@ DEFINE_SPELL_FUN (spell_bless_char) {
     af.modifier = 0 - level / 8;
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel righteous.\n\r", victim);
+    printf_to_char (victim, "You feel righteous.\n\r");
     if (ch != victim)
         act ("You grant $N the favor of your god.", ch, NULL, victim, TO_CHAR);
 }
@@ -133,7 +133,7 @@ void spell_perform_blindness (int sn, int level, CHAR_T *ch,
     affect_init (&af, AFF_TO_AFFECTS, sn, level, 1 + level, APPLY_HITROLL, -4, AFF_BLIND);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You are blinded!\n\r", victim);
+    printf_to_char (victim, "You are blinded!\n\r");
     act ("$n appears to be blinded.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -181,7 +181,7 @@ DEFINE_SPELL_FUN (spell_calm) {
                 affect_is_char_affected (vch, skill_lookup ("frenzy")))
             continue;
 
-        send_to_char ("A wave of calm passes over you.\n\r", vch);
+        printf_to_char (vch, "A wave of calm passes over you.\n\r");
         act ("$n suddenly calms down.", vch, NULL, NULL, TO_NOTCHAR);
 
         if (vch->fighting || vch->position == POS_FIGHTING)
@@ -195,7 +195,7 @@ DEFINE_SPELL_FUN (spell_calm) {
         count++;
     }
     if (count == 0)
-        send_to_char ("Nothing seems to happen.\n\r", ch);
+        printf_to_char (ch, "Nothing seems to happen.\n\r");
 }
 
 DEFINE_SPELL_FUN (spell_change_sex) {
@@ -210,7 +210,7 @@ DEFINE_SPELL_FUN (spell_change_sex) {
     BAIL_IF_ACT (saves_spell (level, victim, DAM_OTHER),
         "$S body refuses to change form.\n\r", ch, NULL, victim);
 
-    send_to_char ("You feel different.\n\r", victim);
+    printf_to_char (victim, "You feel different.\n\r");
     act ("$n doesn't look like $mself anymore...", victim, NULL, NULL,
          TO_NOTCHAR);
 
@@ -308,7 +308,7 @@ void spell_perform_curse_char (int sn, int level, CHAR_T *ch,
     af.modifier  = level / 8;
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel unclean.\n\r", victim);
+    printf_to_char (victim, "You feel unclean.\n\r");
     act ("$n looks very uncomfortable.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -690,14 +690,14 @@ DEFINE_SPELL_FUN (spell_faerie_fire) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level, APPLY_AC, 2 * level, AFF_FAERIE_FIRE);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You are surrounded by a pink outline.\n\r", victim);
+    printf_to_char (victim, "You are surrounded by a pink outline.\n\r");
     act ("$n is surrounded by a pink outline.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
 DEFINE_SPELL_FUN (spell_faerie_fog) {
     CHAR_T *ich;
 
-    send_to_char ("You conjure a cloud of purple smoke.\n\r", ch);
+    printf_to_char (ch, "You conjure a cloud of purple smoke.\n\r");
     act ("$n conjures a cloud of purple smoke.", ch, NULL, NULL, TO_NOTCHAR);
 
     for (ich = ch->in_room->people_first; ich != NULL; ich = ich->room_next) {
@@ -712,7 +712,7 @@ DEFINE_SPELL_FUN (spell_faerie_fog) {
         REMOVE_BIT (ich->affected_by, AFF_HIDE);
         REMOVE_BIT (ich->affected_by, AFF_INVISIBLE);
         REMOVE_BIT (ich->affected_by, AFF_SNEAK);
-        send_to_char ("You are revealed!\n\r", ich);
+        printf_to_char (ich, "You are revealed!\n\r");
         act ("$n is revealed!", ich, NULL, NULL, TO_NOTCHAR);
     }
 }
@@ -729,7 +729,7 @@ DEFINE_SPELL_FUN (spell_fly) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level + 3, 0, 0, AFF_FLYING);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("Your feet rise off the ground.\n\r", victim);
+    printf_to_char (victim, "Your feet rise off the ground.\n\r");
     act ("$n's feet rise off the ground.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -761,7 +761,7 @@ DEFINE_SPELL_FUN (spell_frenzy) {
     af.apply = APPLY_AC;
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You are filled with holy wrath!\n\r", victim);
+    printf_to_char (victim, "You are filled with holy wrath!\n\r");
     act ("$n gets a wild look in $s eyes!", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -777,7 +777,7 @@ DEFINE_SPELL_FUN (spell_giant_strength) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level, APPLY_STR, 1 + (level >= 18) + (level >= 25) + (level >= 32), 0);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("Your muscles surge with heightened power!\n\r", victim);
+    printf_to_char (victim, "Your muscles surge with heightened power!\n\r");
     act ("$n's muscles surge with heightened power.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -790,7 +790,7 @@ DEFINE_SPELL_FUN (spell_haste) {
         || IS_SET (victim->off_flags, OFF_FAST))
     {
         if (victim == ch)
-            send_to_char ("You can't move any faster!\n\r", ch);
+            printf_to_char (ch, "You can't move any faster!\n\r");
         else
             act ("$N is already moving as fast as $E can.", ch, NULL, victim, TO_CHAR);
         return;
@@ -799,12 +799,12 @@ DEFINE_SPELL_FUN (spell_haste) {
     if (IS_AFFECTED (victim, AFF_SLOW)) {
         if (!check_dispel (level, victim, skill_lookup ("slow"))) {
             if (victim != ch)
-                send_to_char ("Spell failed.\n\r", ch);
-            send_to_char ("You feel momentarily faster, then it passes.\n\r", victim);
+                printf_to_char (ch, "Spell failed.\n\r");
+            printf_to_char (victim, "You feel momentarily faster, then it passes.\n\r");
             return;
         }
         if (victim == ch)
-            send_to_char ("You are moving less slowly.\n\r", ch);
+            printf_to_char (ch, "You are moving less slowly.\n\r");
         act ("$n is moving less slowly.", victim, NULL, NULL, TO_NOTCHAR);
         return;
     }
@@ -812,7 +812,7 @@ DEFINE_SPELL_FUN (spell_haste) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level / ((victim == ch) ? 2 : 4), APPLY_DEX, 1 + (level >= 18) + (level >= 25) + (level >= 32), AFF_HASTE);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel yourself moving more quickly.\n\r", victim);
+    printf_to_char (victim, "You feel yourself moving more quickly.\n\r");
     act ("$n is moving more quickly.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -828,7 +828,7 @@ DEFINE_SPELL_FUN (spell_infravision) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, 2 * level, APPLY_NONE, 0, AFF_INFRARED);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("Your eyes glow red.\n\r", victim);
+    printf_to_char (victim, "Your eyes glow red.\n\r");
     act ("$n's eyes glow red.\n\r", ch, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -854,7 +854,7 @@ DEFINE_SPELL_FUN (spell_invis_char) {
             "$N is already invisible."))
         return;
 
-    send_to_char ("You fade out of existence.\n\r", victim);
+    printf_to_char (victim, "You fade out of existence.\n\r");
     act ("$n fades out of existence.", victim, NULL, NULL, TO_NOTCHAR);
 
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level + 12, APPLY_NONE, 0, AFF_INVISIBLE);
@@ -876,7 +876,7 @@ DEFINE_SPELL_FUN (spell_mass_invis) {
     for (gch = ch->in_room->people_first; gch != NULL; gch = gch->room_next) {
         if (!is_same_group (gch, ch) || IS_AFFECTED (gch, AFF_INVISIBLE))
             continue;
-        send_to_char ("You slowly fade out of existence.\n\r", gch);
+        printf_to_char (gch, "You slowly fade out of existence.\n\r");
         act ("$n slowly fades out of existence.", gch, NULL, NULL, TO_NOTCHAR);
 
         affect_init (&af, AFF_TO_AFFECTS, sn, level / 2, 24, APPLY_NONE, 0, AFF_INVISIBLE);
@@ -884,7 +884,7 @@ DEFINE_SPELL_FUN (spell_mass_invis) {
         found = TRUE;
     }
     if (!found)
-        send_to_char ("Nothing happens.\n\r", ch);
+        printf_to_char (ch, "Nothing happens.\n\r");
 }
 
 DEFINE_SPELL_FUN (spell_pass_door) {
@@ -899,7 +899,7 @@ DEFINE_SPELL_FUN (spell_pass_door) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, number_fuzzy (level / 4), APPLY_NONE, 0, AFF_PASS_DOOR);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You turn translucent.\n\r", victim);
+    printf_to_char (victim, "You turn translucent.\n\r");
     act ("$n turns translucent.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -912,7 +912,7 @@ DEFINE_SPELL_FUN (spell_plague) {
         (IS_NPC (victim) && EXT_IS_SET (victim->ext_mob, MOB_UNDEAD)))
     {
         if (ch == victim)
-            send_to_char ("You feel momentarily ill, but it passes.\n\r", ch);
+            printf_to_char (ch, "You feel momentarily ill, but it passes.\n\r");
         else
             act ("$N seems to be unaffected.", ch, NULL, victim, TO_CHAR);
         return;
@@ -939,7 +939,7 @@ DEFINE_SPELL_FUN (spell_poison_char) {
     AFFECT_T af;
 
     if (saves_spell (level, victim, DAM_POISON)) {
-        send_to_char ("You feel momentarily ill, but it passes.\n\r", victim);
+        printf_to_char (victim, "You feel momentarily ill, but it passes.\n\r");
         act ("$n turns slightly green, but it passes.", victim, NULL, NULL,
              TO_NOTCHAR);
         return;
@@ -948,7 +948,7 @@ DEFINE_SPELL_FUN (spell_poison_char) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level, APPLY_STR, -2, AFF_POISON);
     affect_join_char (&af, victim);
 
-    send_to_char ("You feel very sick.\n\r", victim);
+    printf_to_char (victim, "You feel very sick.\n\r");
     act ("$n looks very ill.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -967,7 +967,7 @@ DEFINE_SPELL_FUN (spell_protection_evil) {
         IS_AFFECTED (victim, AFF_PROTECT_GOOD))
     {
         if (victim == ch)
-            send_to_char ("You are already protected.\n\r", ch);
+            printf_to_char (ch, "You are already protected.\n\r");
         else
             act ("$N is already protected.", ch, NULL, victim, TO_CHAR);
         return;
@@ -976,7 +976,7 @@ DEFINE_SPELL_FUN (spell_protection_evil) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, 24, APPLY_SAVING_SPELL, -1, AFF_PROTECT_EVIL);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel holy and pure.\n\r", victim);
+    printf_to_char (victim, "You feel holy and pure.\n\r");
     if (ch != victim)
         act ("$N is protected from evil.", ch, NULL, victim, TO_CHAR);
 }
@@ -989,7 +989,7 @@ DEFINE_SPELL_FUN (spell_protection_good) {
      || IS_AFFECTED (victim, AFF_PROTECT_EVIL))
     {
         if (victim == ch)
-            send_to_char ("You are already protected.\n\r", ch);
+            printf_to_char (ch, "You are already protected.\n\r");
         else
             act ("$N is already protected.", ch, NULL, victim, TO_CHAR);
         return;
@@ -998,7 +998,7 @@ DEFINE_SPELL_FUN (spell_protection_good) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, 24, APPLY_SAVING_SPELL, -1, AFF_PROTECT_GOOD);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel aligned with darkness.\n\r", victim);
+    printf_to_char (victim, "You feel aligned with darkness.\n\r");
     if (ch != victim)
         act ("$N is protected from good.", ch, NULL, victim, TO_CHAR);
 }
@@ -1015,7 +1015,7 @@ DEFINE_SPELL_FUN (spell_sanctuary) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level / 6, APPLY_NONE, 0, AFF_SANCTUARY);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You are surrounded by a white aura.\n\r", victim);
+    printf_to_char (victim, "You are surrounded by a white aura.\n\r");
     act ("$n is surrounded by a white aura.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -1032,7 +1032,7 @@ DEFINE_SPELL_FUN (spell_shield) {
     affect_copy_to_char (&af, victim);
 
     act ("$n is surrounded by a force shield.", victim, NULL, NULL, TO_NOTCHAR);
-    send_to_char ("You are surrounded by a force shield.\n\r", victim);
+    printf_to_char (victim, "You are surrounded by a force shield.\n\r");
 }
 
 DEFINE_SPELL_FUN (spell_sleep) {
@@ -1054,7 +1054,7 @@ DEFINE_SPELL_FUN (spell_sleep) {
         return;
     }
 
-    send_to_char ("You feel very sleepy ..... zzzzzz.\n\r", victim);
+    printf_to_char (victim, "You feel very sleepy ..... zzzzzz.\n\r");
     act ("$n goes to sleep.", victim, NULL, NULL, TO_NOTCHAR);
     victim->position = POS_SLEEPING;
 }
@@ -1072,21 +1072,21 @@ DEFINE_SPELL_FUN (spell_slow) {
         || IS_SET (victim->imm_flags, RES_MAGIC))
     {
         if (victim != ch)
-            send_to_char ("Nothing seemed to happen.\n\r", ch);
-        send_to_char ("You feel momentarily lethargic.\n\r", victim);
+            printf_to_char (ch, "Nothing seemed to happen.\n\r");
+        printf_to_char (victim, "You feel momentarily lethargic.\n\r");
         return;
     }
 
     if (IS_AFFECTED (victim, AFF_HASTE)) {
         if (!check_dispel (level, victim, skill_lookup ("haste"))) {
             if (victim != ch)
-                send_to_char ("Spell failed.\n\r", ch);
-            send_to_char ("You feel momentarily slower, then is passes.\n\r", victim);
+                printf_to_char (ch, "Spell failed.\n\r");
+            printf_to_char (victim, "You feel momentarily slower, then is passes.\n\r");
             return;
         }
 
         if (victim == ch)
-            send_to_char ("You are moving less quickly.\n\r", ch);
+            printf_to_char (ch, "You are moving less quickly.\n\r");
         act ("$n is moving less quickly.", victim, NULL, NULL, TO_NOTCHAR);
         return;
     }
@@ -1094,7 +1094,7 @@ DEFINE_SPELL_FUN (spell_slow) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level / 2, APPLY_DEX, -1 - (level >= 18) - (level >= 25) - (level >= 32), AFF_SLOW);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel yourself slowing d o w n...\n\r", victim);
+    printf_to_char (victim, "You feel yourself slowing d o w n...\n\r");
     act ("$n starts to move in slow motion.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -1110,7 +1110,7 @@ DEFINE_SPELL_FUN (spell_stone_skin) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level, APPLY_AC, -40, 0);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("Your skin turns to stone.\n\r", victim);
+    printf_to_char (victim, "Your skin turns to stone.\n\r");
     act ("$n's skin turns to stone.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -1129,6 +1129,6 @@ DEFINE_SPELL_FUN (spell_weaken) {
     affect_init (&af, AFF_TO_AFFECTS, sn, level, level / 2, APPLY_STR, -1 * (level / 5), AFF_WEAKEN);
     affect_copy_to_char (&af, victim);
 
-    send_to_char ("You feel your strength slip away.\n\r", victim);
+    printf_to_char (victim, "You feel your strength slip away.\n\r");
     act ("$n looks tired and weak.", victim, NULL, NULL, TO_NOTCHAR);
 }

--- a/src/spell_create.c
+++ b/src/spell_create.c
@@ -73,7 +73,7 @@ DEFINE_SPELL_FUN (spell_create_rose) {
     OBJ_T *rose;
     rose = obj_create (obj_get_index (OBJ_VNUM_ROSE), 0);
     obj_give_to_char (rose, ch);
-    send_to_char ("You create a beautiful red rose.\n\r", ch);
+    printf_to_char (ch, "You create a beautiful red rose.\n\r");
     act ("$n has created a beautiful red rose.", ch, rose, NULL, TO_NOTCHAR);
 }
 
@@ -124,7 +124,7 @@ DEFINE_SPELL_FUN (spell_floating_disc) {
     disc->v.container.max_weight = ch->level *  5;  /* 5 pounds/level */
     disc->timer = ch->level * 2 - number_range (0, level / 2);
 
-    send_to_char ("You create a floating disc.\n\r", ch);
+    printf_to_char (ch, "You create a floating disc.\n\r");
     act ("$n has created a floating black disc.", ch, NULL, NULL, TO_NOTCHAR);
 
     obj_give_to_char (disc, ch);

--- a/src/spell_cure.c
+++ b/src/spell_cure.c
@@ -46,7 +46,7 @@ DEFINE_SPELL_FUN (spell_cure_blindness) {
     BAIL_IF (!check_dispel (level, victim, SN(BLINDNESS)),
         "Spell failed.\n\r", ch);
 
-    send_to_char ("Your vision returns!\n\r", victim);
+    printf_to_char (victim, "Your vision returns!\n\r");
     act ("$n is no longer blinded.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -58,7 +58,7 @@ DEFINE_SPELL_FUN (spell_cure_critical) {
     victim->hit = UMIN (victim->hit + heal, victim->max_hit);
     update_pos (victim);
 
-    send_to_char ("You feel much better!\n\r", victim);
+    printf_to_char (victim, "You feel much better!\n\r");
     act ("$n's wounds look much better!", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -74,7 +74,7 @@ DEFINE_SPELL_FUN (spell_cure_disease) {
     BAIL_IF (!check_dispel (level, victim, SN(PLAGUE)),
         "Spell failed.\n\r", ch);
 
-    send_to_char ("Your sores vanish.\n\r", victim);
+    printf_to_char (victim, "Your sores vanish.\n\r");
     act ("$n looks relieved as $s sores vanish.", victim, NULL, NULL,
          TO_NOTCHAR);
 }
@@ -87,7 +87,7 @@ DEFINE_SPELL_FUN (spell_cure_light) {
     victim->hit = UMIN (victim->hit + heal, victim->max_hit);
     update_pos (victim);
 
-    send_to_char ("You feel a little better!\n\r", victim);
+    printf_to_char (victim, "You feel a little better!\n\r");
     act ("$n's wounds look a little better!", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -102,7 +102,7 @@ DEFINE_SPELL_FUN (spell_cure_poison) {
     BAIL_IF (!check_dispel (level, victim, SN(POISON)),
         "Spell failed.\n\r", ch);
 
-    send_to_char ("A warm feeling runs through your body.\n\r", victim);
+    printf_to_char (victim, "A warm feeling runs through your body.\n\r");
     act ("$n looks much healthier.", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -114,7 +114,7 @@ DEFINE_SPELL_FUN (spell_cure_serious) {
     victim->hit = UMIN (victim->hit + heal, victim->max_hit);
     update_pos (victim);
 
-    send_to_char ("You feel better!\n\r", victim);
+    printf_to_char (victim, "You feel better!\n\r");
     act ("$n's wounds look better!", victim, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -123,7 +123,7 @@ DEFINE_SPELL_FUN (spell_heal) {
     victim->hit = UMIN (victim->hit + 100, victim->max_hit);
     update_pos (victim);
 
-    send_to_char ("A warm feeling fills your body and your injuries heal!\n\r", victim);
+    printf_to_char (victim, "A warm feeling fills your body and your injuries heal!\n\r");
     act ("$n glows and recovers from $s injuries!", victim,
         NULL, NULL, TO_NOTCHAR);
 }
@@ -149,11 +149,11 @@ DEFINE_SPELL_FUN (spell_refresh) {
     CHAR_T *victim = (CHAR_T *) vo;
     victim->move = UMIN (victim->move + level, victim->max_move);
     if (victim->max_move == victim->move) {
-        send_to_char ("You feel fully refreshed!\n\r", victim);
+        printf_to_char (victim, "You feel fully refreshed!\n\r");
         act ("$n looks fully refreshed.\n\r", victim, NULL, NULL, TO_NOTCHAR);
     }
     else {
-        send_to_char ("You feel less tired.\n\r", victim);
+        printf_to_char (victim, "You feel less tired.\n\r");
         act ("$n looks less tired.\n\r", victim, NULL, NULL, TO_NOTCHAR);
     }
 }
@@ -186,7 +186,7 @@ DEFINE_SPELL_FUN (spell_remove_curse_char) {
 
     if (check_dispel (level, victim, SN(CURSE))) {
         found = TRUE;
-        send_to_char ("You feel better.\n\r", victim);
+        printf_to_char (victim, "You feel better.\n\r");
         act ("$n looks more relaxed.", victim, NULL, NULL, TO_NOTCHAR);
     }
 
@@ -209,7 +209,7 @@ DEFINE_SPELL_FUN (spell_remove_curse_char) {
     }
 
     if (!found)
-        send_to_char ("Nothing happens.\n\r", ch);
+        printf_to_char (ch, "Nothing happens.\n\r");
 }
 
 DEFINE_SPELL_FUN (spell_remove_curse) {

--- a/src/spell_info.c
+++ b/src/spell_info.c
@@ -300,7 +300,7 @@ void spell_identify_perform_seeded (CHAR_T *ch, OBJ_T *obj, int power) {
 
     if (power <= 100) {
         int percent = (know_pos == 0) ? 100 : (know_count * 100 / know_pos);
-        send_to_char (spell_identify_know_message (percent), ch);
+        printf_to_char (ch, spell_identify_know_message (percent));
     }
 }
 

--- a/src/spell_info.c
+++ b/src/spell_info.c
@@ -156,7 +156,7 @@ void spell_identify_perform_seeded (CHAR_T *ch, OBJ_T *obj, int power) {
                     continue;
                 printf_to_char (ch, " '%s'", skill_table[obj->v.value[i]].name);
             }
-            send_to_char (".\n\r", ch);
+            printf_to_char (ch, ".\n\r");
             break;
         }
 
@@ -182,7 +182,7 @@ void spell_identify_perform_seeded (CHAR_T *ch, OBJ_T *obj, int power) {
             else
                 printf_to_char (ch, " a level %s ability", level_str);
 
-            send_to_char (".\n\r", ch);
+            printf_to_char (ch, ".\n\r");
             break;
         }
 
@@ -292,7 +292,7 @@ void spell_identify_perform_seeded (CHAR_T *ch, OBJ_T *obj, int power) {
             if (paf->duration > -1)
                 printf_to_char (ch, ", %d hours.\n\r", paf->duration);
             else
-                send_to_char (".\n\r", ch);
+                printf_to_char (ch, ".\n\r");
             if (paf->bits)
                 send_to_char (affect_bit_message (paf->bit_type, paf->bits), ch);
         }
@@ -374,7 +374,7 @@ DEFINE_SPELL_FUN (spell_locate_object) {
     }
 
     if (!found)
-        send_to_char ("Nothing like that in heaven or earth.\n\r", ch);
+        printf_to_char (ch, "Nothing like that in heaven or earth.\n\r");
     else
         page_to_char (buf_string (buffer), ch);
 

--- a/src/spell_misc.c
+++ b/src/spell_misc.c
@@ -90,14 +90,14 @@ DEFINE_SPELL_FUN (spell_cancellation) {
 DEFINE_SPELL_FUN (spell_control_weather) {
     if (!str_cmp (target_name, "better")) {
         weather_info.change += dice (level / 3, 4);
-        send_to_char ("You sense the clouds clearing up...\n\r", ch);
+        printf_to_char (ch, "You sense the clouds clearing up...\n\r");
     }
     else if (!str_cmp (target_name, "worse")) {
         weather_info.change -= dice (level / 3, 4);
-        send_to_char ("You sense a storm gathering...\n\r", ch);
+        printf_to_char (ch, "You sense a storm gathering...\n\r");
     }
     else
-        send_to_char ("Do you want it to get better or worse?\n\r", ch);
+        printf_to_char (ch, "Do you want it to get better or worse?\n\r");
 }
 
 /* modified for enhanced use */
@@ -106,8 +106,8 @@ DEFINE_SPELL_FUN (spell_dispel_magic) {
     bool found = FALSE;
 
     if (saves_spell (level, victim, DAM_OTHER)) {
-        send_to_char ("You feel a brief tingling sensation.\n\r", victim);
-        send_to_char ("You notice no change.\n\r", ch);
+        printf_to_char (victim, "You feel a brief tingling sensation.\n\r");
+        printf_to_char (ch, "You notice no change.\n\r");
         return;
     }
 
@@ -196,7 +196,7 @@ DEFINE_SPELL_FUN (spell_recharge) {
         return;
     }
     else if (percent <= UMIN (95, 3 * chance / 2)) {
-        send_to_char ("Nothing seems to happen.\n\r", ch);
+        printf_to_char (ch, "Nothing seems to happen.\n\r");
         if (*recharge_ptr > 0)
             (*recharge_ptr)--;
         return;

--- a/src/spell_move.c
+++ b/src/spell_move.c
@@ -121,7 +121,7 @@ OBJ_T *spell_sub_create_portal (ROOM_INDEX_T *from_room,
 }
 
 void spell_do_gate_teleport (CHAR_T *ch, ROOM_INDEX_T *to_room) {
-    send_to_char ("You step through a gate and vanish.\n\r", ch);
+    printf_to_char (ch, "You step through a gate and vanish.\n\r");
     act ("$n steps through a gate and vanishes.", ch, NULL, NULL, TO_NOTCHAR);
     char_to_room (ch, to_room);
     act ("$n has arrived through a gate.", ch, NULL, NULL, TO_NOTCHAR);
@@ -195,7 +195,7 @@ DEFINE_SPELL_FUN (spell_teleport) {
 
     room_index = room_get_random_index (victim);
     if (victim != ch)
-        send_to_char ("You have been teleported!\n\r", victim);
+        printf_to_char (victim, "You have been teleported!\n\r");
 
     act ("$n vanishes!", victim, NULL, NULL, TO_NOTCHAR);
     char_to_room (victim, room_index);

--- a/src/spell_off.c
+++ b/src/spell_off.c
@@ -82,7 +82,7 @@ DEFINE_SPELL_FUN (spell_call_lightning) {
         "You need bad weather.\n\r", ch);
 
     dam = dice (level / 2, 8);
-    send_to_char ("Mota's lightning strikes your foes!\n\r", ch);
+    printf_to_char (ch, "Mota's lightning strikes your foes!\n\r");
     act ("$n calls Mota's lightning to strike $s foes!",
          ch, NULL, NULL, TO_NOTCHAR);
 
@@ -100,7 +100,7 @@ DEFINE_SPELL_FUN (spell_call_lightning) {
 
         if (vch->in_room->area == ch->in_room->area && IS_OUTSIDE (vch)
             && IS_AWAKE (vch))
-            send_to_char ("Lightning flashes in the sky.\n\r", vch);
+            printf_to_char (vch, "Lightning flashes in the sky.\n\r");
     }
 }
 
@@ -173,7 +173,7 @@ DEFINE_SPELL_FUN (spell_chain_lightning) {
             }
 
             last_vict = ch;
-            send_to_char ("You are struck by your own lightning!\n\r", ch);
+            printf_to_char (ch, "You are struck by your own lightning!\n\r");
             act ("The bolt arcs to $n...whoops!", ch, NULL, NULL, TO_NOTCHAR);
             dam = dice (level, 6);
             if (saves_spell (level, ch, DAM_LIGHTNING))
@@ -245,7 +245,7 @@ DEFINE_SPELL_FUN (spell_demonfire) {
 
     if (!IS_NPC (ch) && !IS_EVIL (ch)) {
         victim = ch;
-        send_to_char ("The demons turn upon you!\n\r", ch);
+        printf_to_char (ch, "The demons turn upon you!\n\r");
     }
 
     ch->alignment = UMAX (-1000, ch->alignment - 50);
@@ -321,7 +321,7 @@ DEFINE_SPELL_FUN (spell_earthquake) {
     CHAR_T *vch;
     CHAR_T *vch_next;
 
-    send_to_char ("The earth trembles beneath your feet!\n\r", ch);
+    printf_to_char (ch, "The earth trembles beneath your feet!\n\r");
     act ("$n makes the earth tremble and shiver.", ch, NULL, NULL, TO_NOTCHAR);
 
     for (vch = char_first; vch != NULL; vch = vch_next) {
@@ -339,7 +339,7 @@ DEFINE_SPELL_FUN (spell_earthquake) {
             continue;
         }
         if (vch->in_room->area == ch->in_room->area)
-            send_to_char ("The earth trembles and shivers.\n\r", vch);
+            printf_to_char (vch, "The earth trembles and shivers.\n\r");
     }
 }
 
@@ -353,8 +353,8 @@ DEFINE_SPELL_FUN (spell_energy_drain) {
         ch->alignment = UMAX (-1000, ch->alignment - 50);
 
     if (saves_spell (level, victim, DAM_NEGATIVE)) {
-        send_to_char ("You are left unsatisfied.\n\r", ch);
-        send_to_char ("You feel a momentary chill.\n\r", victim);
+        printf_to_char (ch, "You are left unsatisfied.\n\r");
+        printf_to_char (victim, "You feel a momentary chill.\n\r");
         return;
     }
 
@@ -368,8 +368,8 @@ DEFINE_SPELL_FUN (spell_energy_drain) {
         ch->hit += dam;
     }
 
-    send_to_char ("You feel your life slipping away!\n\r", victim);
-    send_to_char ("Wow....what a rush!\n\r", ch);
+    printf_to_char (victim, "You feel your life slipping away!\n\r");
+    printf_to_char (ch, "Wow....what a rush!\n\r");
     damage_visible (ch, victim, dam, sn, DAM_NEGATIVE, NULL);
 }
 
@@ -515,8 +515,8 @@ DEFINE_SPELL_FUN (spell_heat_metal) {
     }
 
     if (!success) {
-        send_to_char ("Your spell had no effect.\n\r", ch);
-        send_to_char ("You feel momentarily warmer.\n\r", victim);
+        printf_to_char (ch, "Your spell had no effect.\n\r");
+        printf_to_char (victim, "You feel momentarily warmer.\n\r");
         return;
     }
 
@@ -537,14 +537,14 @@ DEFINE_SPELL_FUN (spell_holy_word) {
     curse_num  = skill_lookup ("curse");
     frenzy_num = skill_lookup ("frenzy");
 
-    send_to_char ("You utter a word of divine power.\n\r", ch);
+    printf_to_char (ch, "You utter a word of divine power.\n\r");
     act ("$n utters a word of divine power!", ch, NULL, NULL, TO_NOTCHAR);
 
     for (vch = ch->in_room->people_first; vch != NULL; vch = vch_next) {
         vch_next = vch->room_next;
 
         if (IS_SAME_ALIGN (ch, vch)) {
-            send_to_char ("You feel even more powerful.\n\r", vch);
+            printf_to_char (vch, "You feel even more powerful.\n\r");
             spell_frenzy (frenzy_num, level, ch, (void *) vch, TARGET_CHAR,
                 target_name);
             spell_bless (bless_num, level, ch, (void *) vch, TARGET_CHAR,
@@ -554,7 +554,7 @@ DEFINE_SPELL_FUN (spell_holy_word) {
                  (IS_EVIL (ch) && IS_GOOD (vch)))
         {
             if (can_attack_spell (ch, vch, TRUE)) {
-                send_to_char ("You are struck down!\n\r", vch);
+                printf_to_char (vch, "You are struck down!\n\r");
                 dam = dice (level, 6);
                 damage_visible (ch, vch, dam, sn, DAM_ENERGY, NULL);
                 spell_curse_char_quiet (curse_num, level, ch, (void *) vch,
@@ -563,7 +563,7 @@ DEFINE_SPELL_FUN (spell_holy_word) {
         }
         else if (IS_NEUTRAL (ch)) {
             if (can_attack_spell (ch, vch, TRUE)) {
-                send_to_char ("You are struck down!\n\r", vch);
+                printf_to_char (vch, "You are struck down!\n\r");
                 dam = dice (level, 4);
                 damage_visible (ch, vch, dam, sn, DAM_ENERGY, NULL);
                 spell_curse_char_quiet (curse_num, level / 2, ch, (void *) vch,
@@ -572,7 +572,7 @@ DEFINE_SPELL_FUN (spell_holy_word) {
         }
     }
 
-    send_to_char ("You feel drained.\n\r", ch);
+    printf_to_char (ch, "You feel drained.\n\r");
     ch->move = 0;
     ch->hit /= 2;
 }
@@ -623,7 +623,7 @@ DEFINE_SPELL_FUN (spell_ray_of_truth) {
 
     if (IS_EVIL (ch)) {
         victim = ch;
-        send_to_char ("The energy explodes inside you!\n\r", ch);
+        printf_to_char (ch, "The energy explodes inside you!\n\r");
     }
 
     if (victim != ch) {

--- a/src/spell_off.c
+++ b/src/spell_off.c
@@ -447,8 +447,9 @@ DEFINE_SPELL_FUN (spell_heat_metal) {
         if (!(is_weapon || is_armor))
             continue;
 
-        /* Flaming weapons being are ignored. */
-        if (is_weapon && IS_WEAPON_STAT (obj_lose, WEAPON_FLAMING))
+        /* Flaming weapons being wielded are ignored. */
+        is_worn   = (obj_lose->wear_loc != WEAR_LOC_NONE);
+        if (is_worn && is_weapon && IS_WEAPON_STAT (obj_lose, WEAPON_FLAMING))
             continue;
 
         success = TRUE;

--- a/src/spell_off.c
+++ b/src/spell_off.c
@@ -425,8 +425,8 @@ DEFINE_SPELL_FUN (spell_heat_metal) {
     if (saves_spell (level + 2, victim, DAM_FIRE)
         || IS_SET (victim->imm_flags, RES_FIRE))
     {
-        send_to_char ("Your spell had no effect.\n\r", ch);
-        send_to_char ("You feel momentarily warmer.\n\r", victim);
+        printf_to_char(ch, "Your spell had no effect.\n\r");
+        printf_to_char(victim, "You feel momentarily warmer.\n\r");
         return;
     }
 
@@ -447,9 +447,8 @@ DEFINE_SPELL_FUN (spell_heat_metal) {
         if (!(is_weapon || is_armor))
             continue;
 
-        /* Flaming weapons being wielded are ignored. */
-        is_worn   = (obj_lose->wear_loc != WEAR_LOC_NONE);
-        if (is_worn && is_weapon && IS_WEAPON_STAT (obj_lose, WEAPON_FLAMING))
+        /* Flaming weapons being are ignored. */
+        if (is_weapon && IS_WEAPON_STAT (obj_lose, WEAPON_FLAMING))
             continue;
 
         success = TRUE;

--- a/src/string.c
+++ b/src/string.c
@@ -31,10 +31,10 @@
  Called by:  none
  ****************************************************************************/
 void string_edit (CHAR_T *ch, char **string_edit) {
-    send_to_char ("-========- Entering EDIT Mode -=========-\n\r", ch);
-    send_to_char ("    Type .h on a new line for help\n\r", ch);
-    send_to_char (" Terminate with a ~ or @ on a blank line.\n\r", ch);
-    send_to_char ("-=======================================-\n\r", ch);
+    printf_to_char (ch, "-========- Entering EDIT Mode -=========-\n\r");
+    printf_to_char (ch, "    Type .h on a new line for help\n\r");
+    printf_to_char (ch, " Terminate with a ~ or @ on a blank line.\n\r");
+    printf_to_char (ch, "-=======================================-\n\r");
 
     if (*string_edit == NULL)
         *string_edit = str_dup ("");
@@ -49,10 +49,10 @@ void string_edit (CHAR_T *ch, char **string_edit) {
  Called by:  (many)olc_act.c
  ****************************************************************************/
 void string_append (CHAR_T *ch, char **string_edit) {
-    send_to_char ("-=======- Entering APPEND Mode -========-\n\r", ch);
-    send_to_char ("    Type .h on a new line for help\n\r", ch);
-    send_to_char (" Terminate with a ~ or @ on a blank line.\n\r", ch);
-    send_to_char ("-=======================================-\n\r", ch);
+    printf_to_char (ch, "-=======- Entering APPEND Mode -========-\n\r");
+    printf_to_char (ch, "    Type .h on a new line for help\n\r");
+    printf_to_char (ch, " Terminate with a ~ or @ on a blank line.\n\r");
+    printf_to_char (ch, "-=======================================-\n\r");
 
     if (*string_edit == NULL)
         *string_edit = str_dup ("");
@@ -109,18 +109,18 @@ void string_add (CHAR_T *ch, char *argument) {
         argument = first_arg (argument, arg3, FALSE);
 
         if (!str_cmp (arg1, ".c")) {
-            send_to_char ("String cleared.\n\r", ch);
+            printf_to_char (ch, "String cleared.\n\r");
             str_replace_dup (ch->desc->string_edit, "");
             return;
         }
         if (!str_cmp (arg1, ".s")) {
-            send_to_char ("String so far:\n\r", ch);
+            printf_to_char (ch, "String so far:\n\r");
             send_to_char (numlines (*ch->desc->string_edit), ch);
             return;
         }
         if (!str_cmp (arg1, ".r")) {
             if (arg2[0] == '\0') {
-                send_to_char ("usage:  .r \"old string\" \"new string\"\n\r", ch);
+                printf_to_char (ch, "usage:  .r \"old string\" \"new string\"\n\r");
                 return;
             }
 
@@ -131,19 +131,19 @@ void string_add (CHAR_T *ch, char *argument) {
         }
         if (!str_cmp (arg1, ".f")) {
             *ch->desc->string_edit = format_string (*ch->desc->string_edit);
-            send_to_char ("String formatted.\n\r", ch);
+            printf_to_char (ch, "String formatted.\n\r");
             return;
         }
         if (!str_cmp (arg1, ".ld")) {
             *ch->desc->string_edit =
                 string_linedel (*ch->desc->string_edit, atoi (arg2));
-            send_to_char ("Line deleted.\n\r", ch);
+            printf_to_char (ch, "Line deleted.\n\r");
             return;
         }
         if (!str_cmp (arg1, ".li")) {
             *ch->desc->string_edit =
                 string_lineadd (*ch->desc->string_edit, tmparg3, atoi (arg2));
-            send_to_char ("Line inserted.\n\r", ch);
+            printf_to_char (ch, "Line inserted.\n\r");
             return;
         }
         if (!str_cmp (arg1, ".lr")) {
@@ -151,25 +151,25 @@ void string_add (CHAR_T *ch, char *argument) {
                 string_linedel (*ch->desc->string_edit, atoi (arg2));
             *ch->desc->string_edit =
                 string_lineadd (*ch->desc->string_edit, tmparg3, atoi (arg2));
-            send_to_char ("Line replaced.\n\r", ch);
+            printf_to_char (ch, "Line replaced.\n\r");
             return;
         }
         if (!str_cmp (arg1, ".h")) {
-            send_to_char ("Sedit help (commands on blank line):   \n\r", ch);
-            send_to_char (".r 'old' 'new'   - replace a substring \n\r", ch);
-            send_to_char ("                   (requires '', \"\") \n\r", ch);
-            send_to_char (".h               - get help (this info)\n\r", ch);
-            send_to_char (".s               - show string so far  \n\r", ch);
-            send_to_char (".f               - (word wrap) string  \n\r", ch);
-            send_to_char (".c               - clear string so far \n\r", ch);
-            send_to_char (".ld <num>        - delete line number <num>\n\r", ch);
-            send_to_char (".li <num> <str>  - insert <str> at line <num>\n\r", ch);
-            send_to_char (".lr <num> <str>  - replace line <num> with <str>\n\r", ch);
-            send_to_char ("@                - end string          \n\r", ch);
+            printf_to_char (ch, "Sedit help (commands on blank line):   \n\r");
+            printf_to_char (ch, ".r 'old' 'new'   - replace a substring \n\r");
+            printf_to_char (ch, "                   (requires '', \"\") \n\r");
+            printf_to_char (ch, ".h               - get help (this info)\n\r");
+            printf_to_char (ch, ".s               - show string so far  \n\r");
+            printf_to_char (ch, ".f               - (word wrap) string  \n\r");
+            printf_to_char (ch, ".c               - clear string so far \n\r");
+            printf_to_char (ch, ".ld <num>        - delete line number <num>\n\r");
+            printf_to_char (ch, ".li <num> <str>  - insert <str> at line <num>\n\r");
+            printf_to_char (ch, ".lr <num> <str>  - replace line <num> with <str>\n\r");
+            printf_to_char (ch, "@                - end string          \n\r");
             return;
         }
 
-        send_to_char ("SEdit:  Invalid dot command.\n\r", ch);
+        printf_to_char (ch, "SEdit:  Invalid dot command.\n\r");
         return;
     }
 
@@ -204,7 +204,7 @@ void string_add (CHAR_T *ch, char *argument) {
      * Edwin strikes again! Fixed avoid adding to a too-long
      * note. JR -- 10/15/00 */
     if (strlen ( *ch->desc->string_edit ) + strlen (argument) >= (MAX_STRING_LENGTH - 4)) {
-        send_to_char ("String too long, last line skipped.\n\r", ch);
+        printf_to_char (ch, "String too long, last line skipped.\n\r");
 
         /* Force character out of editing mode. */
         ch->desc->string_edit = NULL;

--- a/src/string.c
+++ b/src/string.c
@@ -56,7 +56,7 @@ void string_append (CHAR_T *ch, char **string_edit) {
 
     if (*string_edit == NULL)
         *string_edit = str_dup ("");
-    send_to_char (numlines (*string_edit), ch);
+    printf_to_char (ch, numlines (*string_edit));
 
 /* numlines sends the string with \n\r */
 /*  if ( *(*string_edit + strlen( *string_edit ) - 1) != '\r' )
@@ -115,7 +115,7 @@ void string_add (CHAR_T *ch, char *argument) {
         }
         if (!str_cmp (arg1, ".s")) {
             printf_to_char (ch, "String so far:\n\r");
-            send_to_char (numlines (*ch->desc->string_edit), ch);
+            printf_to_char (ch, numlines (*ch->desc->string_edit));
             return;
         }
         if (!str_cmp (arg1, ".r")) {

--- a/src/update.c
+++ b/src/update.c
@@ -338,7 +338,7 @@ void weather_update (void) {
                 continue;
             if (!IS_AWAKE (d->character))
                 continue;
-            send_to_char (buf, d->character);
+            printf_to_char (d->character, buf);
         }
     }
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -332,7 +332,7 @@ void append_file (CHAR_T *ch, char *file, char *str) {
     fclose (reserve_file);
     if ((fp = fopen (file, "a")) == NULL) {
         perror (file);
-        send_to_char ("Could not open the file!\n\r", ch);
+        printf_to_char (ch, "Could not open the file!\n\r");
     }
     else {
         fprintf (fp, "[%5d] %s: %s\n", ch->in_room ? ch->in_room->vnum : 0, ch->name, str);

--- a/src/wiz_im.c
+++ b/src/wiz_im.c
@@ -82,12 +82,12 @@ DEFINE_DO_FUN (do_incognito) {
     if (arg[0] == '\0') {
         if (ch->incog_level) {
             ch->incog_level = 0;
-            send_to_char ("You are no longer cloaked.\n\r", ch);
+            printf_to_char (ch, "You are no longer cloaked.\n\r");
             act ("$n is no longer cloaked.", ch, NULL, NULL, TO_NOTCHAR);
         }
         else {
             ch->incog_level = char_get_trust (ch);
-            send_to_char ("You cloak your presence.\n\r", ch);
+            printf_to_char (ch, "You cloak your presence.\n\r");
             act ("$n cloaks $s presence.", ch, NULL, NULL, TO_NOTCHAR);
         }
         return;
@@ -100,7 +100,7 @@ DEFINE_DO_FUN (do_incognito) {
 
     ch->reply = NULL;
     ch->incog_level = level;
-    send_to_char ("You cloak your presence.\n\r", ch);
+    printf_to_char (ch, "You cloak your presence.\n\r");
     act ("$n cloaks $s presence.", ch, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -116,12 +116,12 @@ DEFINE_DO_FUN (do_invis) {
         /* take the default path */
         if (ch->invis_level) {
             ch->invis_level = 0;
-            send_to_char ("You slowly fade back into existence.\n\r", ch);
+            printf_to_char (ch, "You slowly fade back into existence.\n\r");
             act ("$n slowly fades into existence.", ch, NULL, NULL, TO_NOTCHAR);
         }
         else {
             ch->invis_level = char_get_trust (ch);
-            send_to_char ("You slowly vanish into thin air.\n\r", ch);
+            printf_to_char (ch, "You slowly vanish into thin air.\n\r");
             act ("$n slowly fades into thin air.", ch, NULL, NULL, TO_NOTCHAR);
         }
         return;
@@ -134,7 +134,7 @@ DEFINE_DO_FUN (do_invis) {
 
     ch->reply = NULL;
     ch->invis_level = level;
-    send_to_char ("You slowly vanish into thin air.\n\r", ch);
+    printf_to_char (ch, "You slowly vanish into thin air.\n\r");
     act ("$n slowly fades into thin air.", ch, NULL, NULL, TO_NOTCHAR);
 }
 
@@ -259,7 +259,7 @@ DEFINE_DO_FUN (do_owhere) {
     }
 
     if (!found)
-        send_to_char ("Nothing like that in heaven or earth.\n\r", ch);
+        printf_to_char (ch, "Nothing like that in heaven or earth.\n\r");
     else
         page_to_char (buf_string (buffer), ch);
 
@@ -276,11 +276,11 @@ DEFINE_DO_FUN (do_stat) {
 
     string = one_argument (argument, arg);
     if (arg[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  stat <name>\n\r", ch);
-        send_to_char ("  stat obj <name>\n\r", ch);
-        send_to_char ("  stat mob <name>\n\r", ch);
-        send_to_char ("  stat room <number>\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  stat <name>\n\r");
+        printf_to_char (ch, "  stat obj <name>\n\r");
+        printf_to_char (ch, "  stat mob <name>\n\r");
+        printf_to_char (ch, "  stat room <number>\n\r");
         return;
     }
 
@@ -304,7 +304,7 @@ DEFINE_DO_FUN (do_stat) {
     BAIL_IF_EXPR ((location = find_location (ch, argument)) != NULL,
         do_function (ch, &do_rstat, argument));
 
-    send_to_char ("Nothing by that name found anywhere.\n\r", ch);
+    printf_to_char (ch, "Nothing by that name found anywhere.\n\r");
 }
 
 DEFINE_DO_FUN (do_rstat) {
@@ -337,30 +337,30 @@ DEFINE_DO_FUN (do_rstat) {
     if (location->extra_descr_first != NULL) {
         EXTRA_DESCR_T *ed;
 
-        send_to_char ("Extra description keywords: '", ch);
+        printf_to_char (ch, "Extra description keywords: '");
         for (ed = location->extra_descr_first; ed; ed = ed->on_next) {
             send_to_char (ed->keyword, ch);
             if (ed->on_next != NULL)
-                send_to_char (" ", ch);
+                printf_to_char (ch, " ");
         }
-        send_to_char ("'.\n\r", ch);
+        printf_to_char (ch, "'.\n\r");
     }
 
-    send_to_char ("Characters:", ch);
+    printf_to_char (ch, "Characters:");
     for (rch = location->people_first; rch; rch = rch->room_next) {
         if (!char_can_see_anywhere (ch, rch))
             continue;
         one_argument (rch->name, buf);
         printf_to_char (ch, " %s", buf);
     }
-    send_to_char (".\n\r", ch);
+    printf_to_char (ch, ".\n\r");
 
-    send_to_char ("Objects:   ", ch);
+    printf_to_char (ch, "Objects:   ");
     for (obj = location->content_first; obj; obj = obj->content_next) {
         one_argument (obj->name, buf);
         printf_to_char (ch, " %s", buf);
     }
-    send_to_char (".\n\r", ch);
+    printf_to_char (ch, ".\n\r");
 
     for (door = 0; door < DIR_MAX; door++) {
         EXIT_T *pexit;
@@ -433,7 +433,7 @@ DEFINE_DO_FUN (do_ostat) {
                 printf_to_char (ch, " '%s'", skill_table[obj->v.value[3]].name);
             if (obj->v.value[4] >= 0 && obj->v.value[4] < SKILL_MAX)
                 printf_to_char (ch, " '%s'", skill_table[obj->v.value[4]].name);
-            send_to_char (".\n\r", ch);
+            printf_to_char (ch, ".\n\r");
             break;
 
         case ITEM_WAND:
@@ -442,7 +442,7 @@ DEFINE_DO_FUN (do_ostat) {
                 obj->v.value[1], obj->v.value[2], obj->v.value[0]);
             if (obj->v.value[3] >= 0 && obj->v.value[3] < SKILL_MAX)
                 printf_to_char (ch, " '%s'", skill_table[obj->v.value[3]].name);
-            send_to_char (".\n\r", ch);
+            printf_to_char (ch, ".\n\r");
             break;
 
         case ITEM_DRINK_CON: {
@@ -501,18 +501,18 @@ DEFINE_DO_FUN (do_ostat) {
     if (obj->extra_descr_first || obj->obj_index->extra_descr_first) {
         EXTRA_DESCR_T *ed;
 
-        send_to_char ("Extra description keywords: '", ch);
+        printf_to_char (ch, "Extra description keywords: '");
         for (ed = obj->extra_descr_first; ed; ed = ed->on_next) {
             send_to_char (ed->keyword, ch);
             if (ed->on_next != NULL)
-                send_to_char (" ", ch);
+                printf_to_char (ch, " ");
         }
         for (ed = obj->obj_index->extra_descr_first; ed; ed = ed->on_next) {
             send_to_char (ed->keyword, ch);
             if (ed->on_next != NULL)
-                send_to_char (" ", ch);
+                printf_to_char (ch, " ");
         }
-        send_to_char ("'\n\r", ch);
+        printf_to_char (ch, "'\n\r");
     }
 
     for (paf = obj->affect_first; paf; paf = paf->on_next) {
@@ -522,7 +522,7 @@ DEFINE_DO_FUN (do_ostat) {
         if (paf->duration > -1)
             printf_to_char (ch, ", %d hours.\n\r", paf->duration);
         else
-            send_to_char (".\n\r", ch);
+            printf_to_char (ch, ".\n\r");
 
         if (paf->bits)
             send_to_char (affect_bit_message (paf->bit_type, paf->bits), ch);
@@ -685,12 +685,12 @@ DEFINE_DO_FUN (do_wiznet) {
         return;
     }
     if (!str_prefix (argument, "on")) {
-        send_to_char ("Welcome to Wiznet!\n\r", ch);
+        printf_to_char (ch, "Welcome to Wiznet!\n\r");
         SET_BIT (ch->wiznet, WIZ_ON);
         return;
     }
     if (!str_prefix (argument, "off")) {
-        send_to_char ("Signing off of Wiznet.\n\r", ch);
+        printf_to_char (ch, "Signing off of Wiznet.\n\r");
         REMOVE_BIT (ch->wiznet, WIZ_ON);
         return;
     }
@@ -710,7 +710,7 @@ DEFINE_DO_FUN (do_wiznet) {
         }
         strcat (buf, "\n\r");
 
-        send_to_char ("Wiznet status:\n\r", ch);
+        printf_to_char (ch, "Wiznet status:\n\r");
         send_to_char (buf, ch);
         return;
     }
@@ -728,7 +728,7 @@ DEFINE_DO_FUN (do_wiznet) {
 
         strcat (buf, "\n\r");
 
-        send_to_char ("Wiznet options available to you are:\n\r", ch);
+        printf_to_char (ch, "Wiznet options available to you are:\n\r");
         send_to_char (buf, ch);
         return;
     }
@@ -790,7 +790,7 @@ DEFINE_DO_FUN (do_smote) {
         "You must include your name in an smote.\n\r", ch);
 
     send_to_char (argument, ch);
-    send_to_char ("\n\r", ch);
+    printf_to_char (ch, "\n\r");
 
     for (vch = ch->in_room->people_first; vch != NULL; vch = vch->room_next) {
         if (vch->desc == NULL || vch == ch)
@@ -798,7 +798,7 @@ DEFINE_DO_FUN (do_smote) {
 
         if ((letter = strstr (argument, vch->name)) == NULL) {
             send_to_char (argument, vch);
-            send_to_char ("\n\r", vch);
+            printf_to_char (vch, "\n\r");
             continue;
         }
 
@@ -840,20 +840,20 @@ DEFINE_DO_FUN (do_smote) {
         }
 
         send_to_char (temp, vch);
-        send_to_char ("\n\r", vch);
+        printf_to_char (vch, "\n\r");
     }
 }
 
 /* prefix command: it will put the string typed on each line typed */
 DEFINE_DO_FUN (do_prefi) {
-    send_to_char ("You cannot abbreviate the prefix command.\r\n", ch);
+    printf_to_char (ch, "You cannot abbreviate the prefix command.\r\n");
 }
 
 DEFINE_DO_FUN (do_prefix) {
     if (argument[0] == '\0') {
         BAIL_IF (ch->prefix == NULL || ch->prefix[0] == '\0',
             "You have no prefix to clear.\r\n", ch);
-        send_to_char ("Prefix removed.\r\n", ch);
+        printf_to_char (ch, "Prefix removed.\r\n");
         str_replace_dup (&(ch->prefix), "");
         return;
     }

--- a/src/wiz_im.c
+++ b/src/wiz_im.c
@@ -140,7 +140,7 @@ DEFINE_DO_FUN (do_invis) {
 
 DEFINE_DO_FUN (do_memory) {
     char *buf = mem_dump ("\n\r");
-    send_to_char (buf, ch);
+    printf_to_char (ch, buf);
 }
 
 DEFINE_DO_FUN (do_mwhere) {
@@ -339,7 +339,7 @@ DEFINE_DO_FUN (do_rstat) {
 
         printf_to_char (ch, "Extra description keywords: '");
         for (ed = location->extra_descr_first; ed; ed = ed->on_next) {
-            send_to_char (ed->keyword, ch);
+            printf_to_char (ch, ed->keyword);
             if (ed->on_next != NULL)
                 printf_to_char (ch, " ");
         }
@@ -503,12 +503,12 @@ DEFINE_DO_FUN (do_ostat) {
 
         printf_to_char (ch, "Extra description keywords: '");
         for (ed = obj->extra_descr_first; ed; ed = ed->on_next) {
-            send_to_char (ed->keyword, ch);
+            printf_to_char (ch, ed->keyword);
             if (ed->on_next != NULL)
                 printf_to_char (ch, " ");
         }
         for (ed = obj->obj_index->extra_descr_first; ed; ed = ed->on_next) {
-            send_to_char (ed->keyword, ch);
+            printf_to_char (ch, ed->keyword);
             if (ed->on_next != NULL)
                 printf_to_char (ch, " ");
         }
@@ -711,7 +711,7 @@ DEFINE_DO_FUN (do_wiznet) {
         strcat (buf, "\n\r");
 
         printf_to_char (ch, "Wiznet status:\n\r");
-        send_to_char (buf, ch);
+        printf_to_char (ch, buf);
         return;
     }
 
@@ -729,7 +729,7 @@ DEFINE_DO_FUN (do_wiznet) {
         strcat (buf, "\n\r");
 
         printf_to_char (ch, "Wiznet options available to you are:\n\r");
-        send_to_char (buf, ch);
+        printf_to_char (ch, buf);
         return;
     }
 
@@ -789,7 +789,7 @@ DEFINE_DO_FUN (do_smote) {
     BAIL_IF (strstr (argument, ch->name) == NULL,
         "You must include your name in an smote.\n\r", ch);
 
-    send_to_char (argument, ch);
+    printf_to_char (ch, argument);
     printf_to_char (ch, "\n\r");
 
     for (vch = ch->in_room->people_first; vch != NULL; vch = vch->room_next) {
@@ -797,7 +797,7 @@ DEFINE_DO_FUN (do_smote) {
             continue;
 
         if ((letter = strstr (argument, vch->name)) == NULL) {
-            send_to_char (argument, vch);
+            printf_to_char (vch, argument);
             printf_to_char (vch, "\n\r");
             continue;
         }
@@ -839,7 +839,7 @@ DEFINE_DO_FUN (do_smote) {
             name = vch->name;
         }
 
-        send_to_char (temp, vch);
+        printf_to_char (vch, temp);
         printf_to_char (vch, "\n\r");
     }
 }

--- a/src/wiz_l1.c
+++ b/src/wiz_l1.c
@@ -82,19 +82,19 @@ DEFINE_DO_FUN (do_protect) {
     if (IS_SET (victim->comm, COMM_SNOOP_PROOF)) {
         act_new ("$N is no longer snoop-proof.", ch, NULL, victim, TO_CHAR,
                  POS_DEAD);
-        send_to_char ("Your snoop-proofing was just removed.\n\r", victim);
+        printf_to_char (victim, "Your snoop-proofing was just removed.\n\r");
         REMOVE_BIT (victim->comm, COMM_SNOOP_PROOF);
     }
     else {
         act_new ("$N is now snoop-proof.", ch, NULL, victim, TO_CHAR,
                  POS_DEAD);
-        send_to_char ("You are now immune to snooping.\n\r", victim);
+        printf_to_char (victim, "You are now immune to snooping.\n\r");
         SET_BIT (victim->comm, COMM_SNOOP_PROOF);
     }
 }
 
 DEFINE_DO_FUN (do_reboo) {
-    send_to_char ("If you want to REBOOT, spell it out.\n\r", ch);
+    printf_to_char (ch, "If you want to REBOOT, spell it out.\n\r");
 }
 
 DEFINE_DO_FUN (do_reboot) {
@@ -118,7 +118,7 @@ DEFINE_DO_FUN (do_reboot) {
 }
 
 DEFINE_DO_FUN (do_shutdow) {
-    send_to_char ("If you want to SHUTDOWN, spell it out.\n\r", ch);
+    printf_to_char (ch, "If you want to SHUTDOWN, spell it out.\n\r");
 }
 
 DEFINE_DO_FUN (do_shutdown) {
@@ -154,11 +154,11 @@ DEFINE_DO_FUN (do_log) {
     if (!str_cmp (arg, "all")) {
         if (log_all_commands) {
             log_all_commands = FALSE;
-            send_to_char ("Log ALL off.\n\r", ch);
+            printf_to_char (ch, "Log ALL off.\n\r");
         }
         else {
             log_all_commands = TRUE;
-            send_to_char ("Log ALL on.\n\r", ch);
+            printf_to_char (ch, "Log ALL on.\n\r");
         }
         return;
     }
@@ -171,10 +171,10 @@ DEFINE_DO_FUN (do_log) {
     /* No level check, gods can log anyone. */
     if (EXT_IS_SET (victim->ext_plr, PLR_LOG)) {
         EXT_UNSET (victim->ext_plr, PLR_LOG);
-        send_to_char ("LOG removed.\n\r", ch);
+        printf_to_char (ch, "LOG removed.\n\r");
     }
     else {
         EXT_SET (victim->ext_plr, PLR_LOG);
-        send_to_char ("LOG set.\n\r", ch);
+        printf_to_char (ch, "LOG set.\n\r");
     }
 }

--- a/src/wiz_l2.c
+++ b/src/wiz_l2.c
@@ -63,7 +63,7 @@ DEFINE_DO_FUN (do_allow) {
         return;
     }
 
-    send_to_char ("Site is not banned.\n\r", ch);
+    printf_to_char (ch, "Site is not banned.\n\r");
 }
 
 DEFINE_DO_FUN (do_ban) {
@@ -77,12 +77,12 @@ DEFINE_DO_FUN (do_set) {
     argument = one_argument (argument, arg);
 
     if (arg[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  set mob       <name> <field> <value>\n\r", ch);
-        send_to_char ("  set character <name> <field> <value>\n\r", ch);
-        send_to_char ("  set obj       <name> <field> <value>\n\r", ch);
-        send_to_char ("  set room      <room> <field> <value>\n\r", ch);
-        send_to_char ("  set skill     <name> <spell or skill> <value>\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  set mob       <name> <field> <value>\n\r");
+        printf_to_char (ch, "  set character <name> <field> <value>\n\r");
+        printf_to_char (ch, "  set obj       <name> <field> <value>\n\r");
+        printf_to_char (ch, "  set room      <room> <field> <value>\n\r");
+        printf_to_char (ch, "  set skill     <name> <spell or skill> <value>\n\r");
         return;
     }
 
@@ -113,10 +113,10 @@ DEFINE_DO_FUN (do_sset) {
     argument = one_argument (argument, arg3);
 
     if (arg1[0] == '\0' || arg2[0] == '\0' || arg3[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  set skill <name> <spell or skill> <value>\n\r", ch);
-        send_to_char ("  set skill <name> all <value>\n\r", ch);
-        send_to_char ("   (use the name of the skill, not the number)\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  set skill <name> <spell or skill> <value>\n\r");
+        printf_to_char (ch, "  set skill <name> all <value>\n\r");
+        printf_to_char (ch, "   (use the name of the skill, not the number)\n\r");
         return;
     }
 
@@ -162,13 +162,13 @@ DEFINE_DO_FUN (do_mset) {
     strcpy (arg3, argument);
 
     if (arg1[0] == '\0' || arg2[0] == '\0' || arg3[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  set char <name> <field> <value>\n\r", ch);
-        send_to_char ("  Field being one of:\n\r", ch);
-        send_to_char ("    str int wis dex con sex class level\n\r", ch);
-        send_to_char ("    race group gold silver hp mana move prac\n\r", ch);
-        send_to_char ("    align train thirst hunger drunk full\n\r", ch);
-        send_to_char ("    security hours\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  set char <name> <field> <value>\n\r");
+        printf_to_char (ch, "  Field being one of:\n\r");
+        printf_to_char (ch, "    str int wis dex con sex class level\n\r");
+        printf_to_char (ch, "    race group gold silver hp mana move prac\n\r");
+        printf_to_char (ch, "    align train thirst hunger drunk full\n\r");
+        printf_to_char (ch, "    security hours\n\r");
         return;
     }
 
@@ -201,7 +201,7 @@ DEFINE_DO_FUN (do_mset) {
             if (ch->pcdata->security != 0)
                 printf_to_char (ch, "Valid security is 0-%d.\n\r", ch->pcdata->security);
             else
-                send_to_char ("Valid security is 0 only.\n\r", ch);
+                printf_to_char (ch, "Valid security is 0 only.\n\r");
             return;
         }
         victim->pcdata->security = value;
@@ -434,11 +434,11 @@ DEFINE_DO_FUN (do_oset) {
     strcpy (arg3, argument);
 
     if (arg1[0] == '\0' || arg2[0] == '\0' || arg3[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  set obj <object> <field> <value>\n\r", ch);
-        send_to_char ("  Field being one of:\n\r", ch);
-        send_to_char ("    value0 value1 value2 value3 value4 (v1-v4)\n\r", ch);
-        send_to_char ("    extra wear level weight cost timer\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  set obj <object> <field> <value>\n\r");
+        printf_to_char (ch, "  Field being one of:\n\r");
+        printf_to_char (ch, "    value0 value1 value2 value3 value4 (v1-v4)\n\r");
+        printf_to_char (ch, "    extra wear level weight cost timer\n\r");
         return;
     }
     BAIL_IF ((obj = find_obj_world (ch, arg1)) == NULL,
@@ -488,10 +488,10 @@ DEFINE_DO_FUN (do_rset) {
     strcpy (arg3, argument);
 
     if (arg1[0] == '\0' || arg2[0] == '\0' || arg3[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  set room <location> <field> <value>\n\r", ch);
-        send_to_char ("  Field being one of:\n\r", ch);
-        send_to_char ("    flags sector\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  set room <location> <field> <value>\n\r");
+        printf_to_char (ch, "  Field being one of:\n\r");
+        printf_to_char (ch, "    flags sector\n\r");
         return;
     }
     BAIL_IF ((location = find_location (ch, arg1)) == NULL,
@@ -521,10 +521,10 @@ DEFINE_DO_FUN (do_wizlock) {
 
     if (wizlock) {
         wiznet ("$N has wizlocked the game.", ch, NULL, 0, 0, 0);
-        send_to_char ("Game wizlocked.\n\r", ch);
+        printf_to_char (ch, "Game wizlocked.\n\r");
     }
     else {
         wiznet ("$N removes wizlock.", ch, NULL, 0, 0, 0);
-        send_to_char ("Game un-wizlocked.\n\r", ch);
+        printf_to_char (ch, "Game un-wizlocked.\n\r");
     }
 }

--- a/src/wiz_l2.c
+++ b/src/wiz_l2.c
@@ -273,7 +273,7 @@ DEFINE_DO_FUN (do_mset) {
             }
             strcat (buf, ".\n\r");
 
-            send_to_char (buf, ch);
+            printf_to_char (ch, buf);
             return;
         }
 

--- a/src/wiz_l3.c
+++ b/src/wiz_l3.c
@@ -96,25 +96,25 @@ DEFINE_DO_FUN (do_pardon) {
     if (!str_cmp (arg2, "killer")) {
         if (EXT_IS_SET (victim->ext_plr, PLR_KILLER)) {
             EXT_UNSET (victim->ext_plr, PLR_KILLER);
-            send_to_char ("Killer flag removed.\n\r", ch);
-            send_to_char ("You are no longer a KILLER.\n\r", victim);
+            printf_to_char (ch, "Killer flag removed.\n\r");
+            printf_to_char (victim, "You are no longer a KILLER.\n\r");
         }
         return;
     }
     if (!str_cmp (arg2, "thief")) {
         if (EXT_IS_SET (victim->ext_plr, PLR_THIEF)) {
             EXT_UNSET (victim->ext_plr, PLR_THIEF);
-            send_to_char ("Thief flag removed.\n\r", ch);
-            send_to_char ("You are no longer a THIEF.\n\r", victim);
+            printf_to_char (ch, "Thief flag removed.\n\r");
+            printf_to_char (victim, "You are no longer a THIEF.\n\r");
         }
         return;
     }
 
-    send_to_char ("Syntax: pardon <character> <killer|thief>.\n\r", ch);
+    printf_to_char (ch, "Syntax: pardon <character> <killer|thief>.\n\r");
 }
 
 DEFINE_DO_FUN (do_sla)
-    { send_to_char ("If you want to SLAY, spell it out.\n\r", ch); }
+    { printf_to_char (ch, "If you want to SLAY, spell it out.\n\r"); }
 
 DEFINE_DO_FUN (do_slay) {
     CHAR_T *victim;

--- a/src/wiz_l4.c
+++ b/src/wiz_l4.c
@@ -62,8 +62,8 @@ DEFINE_DO_FUN (do_guild) {
         "They aren't playing.\n\r", ch);
 
     if (!str_cmp (arg2, "none")) {
-        send_to_char ("They are now clanless.\n\r", ch);
-        send_to_char ("You are now a member of no clan!\n\r", victim);
+        printf_to_char (ch, "They are now clanless.\n\r");
+        printf_to_char (victim, "You are now a member of no clan!\n\r");
         victim->clan = 0;
         return;
     }
@@ -141,13 +141,13 @@ DEFINE_DO_FUN (do_flag) {
         argument = one_argument (argument, word);
 
     if (arg1[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  flag mob  <name> <field> <flags>\n\r", ch);
-        send_to_char ("  flag char <name> <field> <flags>\n\r", ch);
-        send_to_char ("  mob  flags: mob, aff, off, imm, res, vuln, form, part\n\r", ch);
-        send_to_char ("  char flags: plr, comm, aff, imm, res, vuln\n\r", ch);
-        send_to_char ("  +: add flag, -: remove flag, = set equal to\n\r", ch);
-        send_to_char ("  otherwise flag toggles the flags listed.\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  flag mob  <name> <field> <flags>\n\r");
+        printf_to_char (ch, "  flag char <name> <field> <flags>\n\r");
+        printf_to_char (ch, "  mob  flags: mob, aff, off, imm, res, vuln, form, part\n\r");
+        printf_to_char (ch, "  char flags: plr, comm, aff, imm, res, vuln\n\r");
+        printf_to_char (ch, "  +: add flag, -: remove flag, = set equal to\n\r");
+        printf_to_char (ch, "  otherwise flag toggles the flags listed.\n\r");
         return;
     }
 
@@ -214,7 +214,7 @@ DEFINE_DO_FUN (do_flag) {
         flag_table = comm_flags;
     }
     else {
-        send_to_char ("That's not an acceptable flag.\n\r", ch);
+        printf_to_char (ch, "That's not an acceptable flag.\n\r");
         return;
     }
 
@@ -297,15 +297,15 @@ DEFINE_DO_FUN (do_freeze) {
         "You failed.\n\r", ch);
     if (EXT_IS_SET (victim->ext_plr, PLR_FREEZE)) {
         EXT_UNSET (victim->ext_plr, PLR_FREEZE);
-        send_to_char ("You can play again.\n\r", victim);
-        send_to_char ("FREEZE removed.\n\r", ch);
+        printf_to_char (victim, "You can play again.\n\r");
+        printf_to_char (ch, "FREEZE removed.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N thaws %s.", victim->name);
     }
     else {
         EXT_SET (victim->ext_plr, PLR_FREEZE);
-        send_to_char ("You can't do ANYthing!\n\r", victim);
-        send_to_char ("FREEZE set.\n\r", ch);
+        printf_to_char (victim, "You can't do ANYthing!\n\r");
+        printf_to_char (ch, "FREEZE set.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N puts %s in the deep freeze.", victim->name);
     }
@@ -319,9 +319,9 @@ DEFINE_DO_FUN (do_load) {
 
     argument = one_argument (argument, arg);
     if (arg[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  load mob <vnum>\n\r", ch);
-        send_to_char ("  load obj <vnum> <level>\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  load mob <vnum>\n\r");
+        printf_to_char (ch, "  load obj <vnum> <level>\n\r");
         return;
     }
     BAIL_IF_EXPR (!str_cmp (arg, "mob") || !str_cmp (arg, "char"),
@@ -400,7 +400,7 @@ DEFINE_DO_FUN (do_pecho) {
 
     if (char_get_trust (victim) >= char_get_trust (ch) &&
             char_get_trust (ch) != MAX_LEVEL)
-        send_to_char ("personal> ", victim);
+        printf_to_char (victim, "personal> ");
 
     printf_to_char (victim, "%s\n\r", argument);
     printf_to_char (ch, "personal> %s\n\r", argument);
@@ -443,7 +443,7 @@ DEFINE_DO_FUN (do_purge) {
             "Ho ho ho.\n\r", ch);
 
         if (char_get_trust (ch) <= char_get_trust (victim)) {
-            send_to_char ("Maybe that wasn't a good idea...\n\r", ch);
+            printf_to_char (ch, "Maybe that wasn't a good idea...\n\r");
             printf_to_char (victim, "%s tried to purge you!\n\r", ch->name);
             return;
         }
@@ -493,7 +493,7 @@ DEFINE_DO_FUN (do_restore) {
 
         wiznetf (ch, NULL, WIZ_RESTORE, WIZ_SECURE, char_get_trust (ch),
             "$N restored room %d.", ch->in_room->vnum);
-        send_to_char ("Room restored.\n\r", ch);
+        printf_to_char (ch, "Room restored.\n\r");
         return;
     }
 
@@ -508,7 +508,7 @@ DEFINE_DO_FUN (do_restore) {
 
         wiznet ("$N restored all players.", ch, NULL, WIZ_RESTORE, WIZ_SECURE,
             char_get_trust (ch));
-        send_to_char ("All active players restored.\n\r", ch);
+        printf_to_char (ch, "All active players restored.\n\r");
         return;
     }
 
@@ -540,10 +540,10 @@ DEFINE_DO_FUN (do_vnum) {
 
     string = one_argument (argument, arg);
     if (arg[0] == '\0') {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  vnum obj <name>\n\r", ch);
-        send_to_char ("  vnum mob <name>\n\r", ch);
-        send_to_char ("  vnum skill <skill or spell>\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  vnum obj <name>\n\r");
+        printf_to_char (ch, "  vnum mob <name>\n\r");
+        printf_to_char (ch, "  vnum skill <skill or spell>\n\r");
         return;
     }
 
@@ -596,7 +596,7 @@ DEFINE_DO_FUN (do_mfind) {
         }
     }
     if (matches == 0)
-        send_to_char ("No mobiles by that name.\n\r", ch);
+        printf_to_char (ch, "No mobiles by that name.\n\r");
     else
         printf_to_char (ch, "Found %d mobiles.\n\r", matches);
 }
@@ -617,7 +617,7 @@ DEFINE_DO_FUN (do_ofind) {
         }
     }
     if (matches == 0)
-        send_to_char ("No objects by that name.\n\r", ch);
+        printf_to_char (ch, "No objects by that name.\n\r");
     else
         printf_to_char (ch, "Found %d objects.\n\r", matches);
 }

--- a/src/wiz_l5.c
+++ b/src/wiz_l5.c
@@ -97,7 +97,7 @@ DEFINE_DO_FUN (do_nochannels) {
         REMOVE_BIT (victim->comm, COMM_NOCHANNELS);
         send_to_char ("The gods have restored your channel priviliges.\n\r",
                       victim);
-        send_to_char ("NOCHANNELS removed.\n\r", ch);
+        printf_to_char (ch, "NOCHANNELS removed.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N restores channels to %s", victim->name);
     }
@@ -105,7 +105,7 @@ DEFINE_DO_FUN (do_nochannels) {
         SET_BIT (victim->comm, COMM_NOCHANNELS);
         send_to_char ("The gods have revoked your channel priviliges.\n\r",
                       victim);
-        send_to_char ("NOCHANNELS set.\n\r", ch);
+        printf_to_char (ch, "NOCHANNELS set.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N revokes %s's channels.", victim->name);
     }
@@ -125,15 +125,15 @@ DEFINE_DO_FUN (do_noemote) {
 
     if (IS_SET (victim->comm, COMM_NOEMOTE)) {
         REMOVE_BIT (victim->comm, COMM_NOEMOTE);
-        send_to_char ("You can emote again.\n\r", victim);
-        send_to_char ("NOEMOTE removed.\n\r", ch);
+        printf_to_char (victim, "You can emote again.\n\r");
+        printf_to_char (ch, "NOEMOTE removed.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N restores emotes to %s.", victim->name);
     }
     else {
         SET_BIT (victim->comm, COMM_NOEMOTE);
-        send_to_char ("You can't emote!\n\r", victim);
-        send_to_char ("NOEMOTE set.\n\r", ch);
+        printf_to_char (victim, "You can't emote!\n\r");
+        printf_to_char (ch, "NOEMOTE set.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N revokes %s's emotes.", victim->name);
     }
@@ -155,15 +155,15 @@ DEFINE_DO_FUN (do_noshout) {
 
     if (IS_SET (victim->comm, COMM_NOSHOUT)) {
         REMOVE_BIT (victim->comm, COMM_NOSHOUT);
-        send_to_char ("You can shout again.\n\r", victim);
-        send_to_char ("NOSHOUT removed.\n\r", ch);
+        printf_to_char (victim, "You can shout again.\n\r");
+        printf_to_char (ch, "NOSHOUT removed.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N restores shouts to %s.", victim->name);
     }
     else {
         SET_BIT (victim->comm, COMM_NOSHOUT);
-        send_to_char ("You can't shout!\n\r", victim);
-        send_to_char ("NOSHOUT set.\n\r", ch);
+        printf_to_char (victim, "You can't shout!\n\r");
+        printf_to_char (ch, "NOSHOUT set.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N revokes %s's shouts.", victim->name);
     }
@@ -183,15 +183,15 @@ DEFINE_DO_FUN (do_notell) {
 
     if (IS_SET (victim->comm, COMM_NOTELL)) {
         REMOVE_BIT (victim->comm, COMM_NOTELL);
-        send_to_char ("You can tell again.\n\r", victim);
-        send_to_char ("NOTELL removed.\n\r", ch);
+        printf_to_char (victim, "You can tell again.\n\r");
+        printf_to_char (ch, "NOTELL removed.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N restores tells to %s.", victim->name);
     }
     else {
         SET_BIT (victim->comm, COMM_NOTELL);
-        send_to_char ("You can't tell!\n\r", victim);
-        send_to_char ("NOTELL set.\n\r", ch);
+        printf_to_char (victim, "You can't tell!\n\r");
+        printf_to_char (ch, "NOTELL set.\n\r");
         wiznetf (ch, NULL, WIZ_PENALTIES, WIZ_SECURE, 0,
             "$N revokes %s's tells.", victim->name);
     }
@@ -276,7 +276,7 @@ DEFINE_DO_FUN (do_snoop) {
         "No descriptor to snoop.\n\r", ch);
 
     if (victim == ch) {
-        send_to_char ("Cancelling all snoops.\n\r", ch);
+        printf_to_char (ch, "Cancelling all snoops.\n\r");
         wiznet ("$N stops being such a snoop.",
                 ch, NULL, WIZ_SNOOPS, WIZ_SECURE, char_get_trust (ch));
         for (d = descriptor_first; d != NULL; d = d->global_next)
@@ -325,11 +325,11 @@ DEFINE_DO_FUN (do_string) {
     if (type[0] == '\0' || arg1[0] == '\0' || arg2[0] == '\0'
         || arg3[0] == '\0')
     {
-        send_to_char ("Syntax:\n\r", ch);
-        send_to_char ("  string char <name> <field> <string>\n\r", ch);
-        send_to_char ("    fields: name short long desc title spec\n\r", ch);
-        send_to_char ("  string obj  <name> <field> <string>\n\r", ch);
-        send_to_char ("    fields: name short long extended\n\r", ch);
+        printf_to_char (ch, "Syntax:\n\r");
+        printf_to_char (ch, "  string char <name> <field> <string>\n\r");
+        printf_to_char (ch, "    fields: name short long desc title spec\n\r");
+        printf_to_char (ch, "  string obj  <name> <field> <string>\n\r");
+        printf_to_char (ch, "    fields: name short long extended\n\r");
         return;
     }
 
@@ -504,10 +504,10 @@ DEFINE_DO_FUN (do_newlock) {
 
     if (newlock) {
         wiznet ("$N locks out new characters.", ch, NULL, 0, 0, 0);
-        send_to_char ("New characters have been locked out.\n\r", ch);
+        printf_to_char (ch, "New characters have been locked out.\n\r");
     }
     else {
         wiznet ("$N allows new characters back in.", ch, NULL, 0, 0, 0);
-        send_to_char ("Newlock removed.\n\r", ch);
+        printf_to_char (ch, "Newlock removed.\n\r");
     }
 }

--- a/src/wiz_ml.c
+++ b/src/wiz_ml.c
@@ -245,11 +245,11 @@ DEFINE_DO_FUN (do_dump) {
             return;
         }
 
-        send_to_char (DO_DUMP_WORLD_SYNTAX, ch);
+        printf_to_char (ch, DO_DUMP_WORLD_SYNTAX);
         return;
     }
 
-    send_to_char (DO_DUMP_SYNTAX, ch);
+    printf_to_char (ch, DO_DUMP_SYNTAX);
 }
 
 void do_dump_stats (CHAR_T *ch) {

--- a/src/wiz_ml.c
+++ b/src/wiz_ml.c
@@ -82,8 +82,8 @@ DEFINE_DO_FUN (do_advance) {
      *   -- Swiftest */
     if (level <= victim->level) {
         int temp_prac;
-        send_to_char ("Lowering a player's level!\n\r", ch);
-        send_to_char ("**** OOOOHHHHHHHHHH  NNNNOOOO ****\n\r", victim);
+        printf_to_char (ch, "Lowering a player's level!\n\r");
+        printf_to_char (victim, "**** OOOOHHHHHHHHHH  NNNNOOOO ****\n\r");
         temp_prac = victim->practice;
         victim->level = 1;
         victim->exp = player_get_exp_per_level (victim);
@@ -98,8 +98,8 @@ DEFINE_DO_FUN (do_advance) {
         victim->practice = temp_prac;
     }
     else {
-        send_to_char ("Raising a player's level!\n\r", ch);
-        send_to_char ("**** OOOOHHHHHHHHHH  YYYYEEEESSS ****\n\r", victim);
+        printf_to_char (ch, "Raising a player's level!\n\r");
+        printf_to_char (victim, "**** OOOOHHHHHHHHHH  YYYYEEEESSS ****\n\r");
     }
     for (i = victim->level; i < level; i++) {
         victim->level += 1;
@@ -123,7 +123,7 @@ DEFINE_DO_FUN (do_copyover) {
     fp = fopen (COPYOVER_FILE, "w");
 
     if (!fp) {
-        send_to_char ("Copyover file not writeable, aborted.\n\r", ch);
+        printf_to_char (ch, "Copyover file not writeable, aborted.\n\r");
         log_f ("Could not write to copyover file: %s", COPYOVER_FILE);
         perror ("do_copyover:fopen");
         return;
@@ -187,7 +187,7 @@ DEFINE_DO_FUN (do_copyover) {
 
     /* Failed - sucessful exec will not return */
     perror ("do_copyover: execl");
-    send_to_char ("Copyover FAILED!\n\r", ch);
+    printf_to_char (ch, "Copyover FAILED!\n\r");
 
     /* Here you might want to reopen reserve_file */
     reserve_file = fopen (NULL_FILE, "r");
@@ -305,7 +305,7 @@ void do_dump_stats (CHAR_T *ch) {
 
     /* unlock writing? */
     reserve_file = fopen (NULL_FILE, "r");
-    send_to_char ("Done.\n\r", ch);
+    printf_to_char (ch, "Done.\n\r");
 }
 
 void do_dump_world_raw (CHAR_T *ch) {
@@ -317,7 +317,7 @@ void do_dump_world_raw (CHAR_T *ch) {
     db_dump_world (DUMP_DIR "world.dump");
 
     reserve_file = fopen (NULL_FILE, "r");
-    send_to_char ("Done.\n\r", ch);
+    printf_to_char (ch, "Done.\n\r");
 }
 
 void do_dump_world_json (CHAR_T *ch) {
@@ -329,7 +329,7 @@ void do_dump_world_json (CHAR_T *ch) {
     json_export_all (FALSE, DUMP_DIR "world.json");
 
     reserve_file = fopen (NULL_FILE, "r");
-    send_to_char ("Done.\n\r", ch);
+    printf_to_char (ch, "Done.\n\r");
 }
 
 DEFINE_DO_FUN (do_violate) {
@@ -528,24 +528,24 @@ void do_jsave_area (CHAR_T *ch, const char *arg) {
     /* Listing possibilities? */
     if (!str_cmp ("list", arg)) {
         int col = 0;
-        send_to_char ("Areas that can be saved:\n\r", ch);
+        printf_to_char (ch, "Areas that can be saved:\n\r");
 
         for (area = area_first; area; area = area->global_next) {
             if (col % 7 == 0)
-                send_to_char ("  ", ch);
+                printf_to_char (ch, "  ");
             printf_to_char (ch, "%-10s", area->name);
             if (++col % 7 == 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
         }
         if (col % 7 != 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
 
         return;
     }
 
     /* Are we saving all? */
     if (!str_cmp ("all", arg)) {
-        send_to_char ("Saving all areas...\n\r", ch);
+        printf_to_char (ch, "Saving all areas...\n\r");
         desc_flush_output (ch->desc);
 
         for (area = area_first; area; area = area->global_next) {
@@ -554,7 +554,7 @@ void do_jsave_area (CHAR_T *ch, const char *arg) {
             json_export_area (area, JSON_EXPORT_MODE_SAVE);
         }
 
-        send_to_char ("Done.\n\r", ch);
+        printf_to_char (ch, "Done.\n\r");
         return;
     }
 
@@ -578,24 +578,24 @@ void do_jsave_help (CHAR_T *ch, const char *arg) {
     /* Listing possibilities? */
     if (!str_cmp ("list", arg)) {
         int col = 0;
-        send_to_char ("Helps that can be saved:\n\r", ch);
+        printf_to_char (ch, "Helps that can be saved:\n\r");
 
         for (had = had_first; had; had = had->global_next) {
             if (col % 7 == 0)
-                send_to_char ("  ", ch);
+                printf_to_char (ch, "  ");
             printf_to_char (ch, "%-10s", had->name);
             if (++col % 7 == 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
         }
         if (col % 7 != 0)
-            send_to_char ("\n\r", ch);
+            printf_to_char (ch, "\n\r");
 
         return;
     }
 
     /* Are we saving all? */
     if (!str_cmp ("all", arg)) {
-        send_to_char ("Saving all helps...\n\r", ch);
+        printf_to_char (ch, "Saving all helps...\n\r");
         desc_flush_output (ch->desc);
 
         for (had = had_first; had; had = had->global_next) {
@@ -604,7 +604,7 @@ void do_jsave_help (CHAR_T *ch, const char *arg) {
             json_export_help_area (had, JSON_EXPORT_MODE_SAVE);
         }
 
-        send_to_char ("Done.\n\r", ch);
+        printf_to_char (ch, "Done.\n\r");
         return;
     }
 
@@ -645,7 +645,7 @@ void do_jsave_table (CHAR_T *ch, const char *arg) {
             }
 
             if (restrict_type > 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
             printf_to_char (ch, "Tables of type '%s' can be saved:\n\r",
                 type_name);
 
@@ -656,13 +656,13 @@ void do_jsave_table (CHAR_T *ch, const char *arg) {
                 if (!json_can_export_table (table))
                     continue;
                 if (col % 4 == 0)
-                    send_to_char ("  ", ch);
+                    printf_to_char (ch, "  ");
                 printf_to_char (ch, "%-19s", table->name);
                 if (++col % 4 == 0)
-                    send_to_char ("\n\r", ch);
+                    printf_to_char (ch, "\n\r");
             }
             if (col % 4 != 0)
-                send_to_char ("\n\r", ch);
+                printf_to_char (ch, "\n\r");
         }
 
         return;
@@ -670,27 +670,27 @@ void do_jsave_table (CHAR_T *ch, const char *arg) {
 
     /* Are we saving all? */
     if (!str_cmp ("flags", arg)) {
-        send_to_char ("Saving all tables of type 'flags'...\n\r", ch);
+        printf_to_char (ch, "Saving all tables of type 'flags'...\n\r");
         save_all = TRUE;
         restrict_type = TABLE_FLAGS;
     }
     else if (!str_cmp ("ext_flags", arg)) {
-        send_to_char ("Saving all tables of type 'ext_flags'...\n\r", ch);
+        printf_to_char (ch, "Saving all tables of type 'ext_flags'...\n\r");
         save_all = TRUE;
         restrict_type = TABLE_EXT_FLAGS;
     }
     else if (!str_cmp ("types", arg)) {
-        send_to_char ("Saving all tables of type 'types'...\n\r", ch);
+        printf_to_char (ch, "Saving all tables of type 'types'...\n\r");
         save_all = TRUE;
         restrict_type = TABLE_TYPES;
     }
     else if (!str_cmp ("unique", arg)) {
-        send_to_char ("Saving all tables of type 'unique'...\n\r", ch);
+        printf_to_char (ch, "Saving all tables of type 'unique'...\n\r");
         save_all = TRUE;
         restrict_type = TABLE_UNIQUE;
     }
     else if (!str_cmp ("all", arg)) {
-        send_to_char ("Saving all tables...\n\r", ch);
+        printf_to_char (ch, "Saving all tables...\n\r");
         save_all = TRUE;
         restrict_type = -1;
     }
@@ -712,7 +712,7 @@ void do_jsave_table (CHAR_T *ch, const char *arg) {
             json_export_table (table, JSON_EXPORT_MODE_SAVE);
         }
 
-        send_to_char ("Done.\n\r", ch);
+        printf_to_char (ch, "Done.\n\r");
         return;
     }
 


### PR DESCRIPTION
I scripted the changes with regex initially, but have some remaining ones to go through manually that did not match my case (roughly 800 instances in total).

Find:  send_to_char\s\((".*?"),\s(.+?(?=\)))\);

Replace:  printf_to_char ($2, $1);