### PR TITLE
Minor tweaks to improve build stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Filename: Dockerfile
 
-FROM ubuntu
+FROM ubuntu:focal
 
 RUN apt-get update && apt-get install -y \
 	nano \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ cd ..
 OR using Docker to startup and shutdown:
 
 ```
+docker-compose build
 docker-compose up
 
 docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3"
 services:
   app:
-    image: base
+    image: basemud:latest
+    build:
+      context: .
     volumes:
       - ./log:/opt/rom/log:rw
       - ./player:/opt/rom/player:rw

--- a/src/comm.h
+++ b/src/comm.h
@@ -48,39 +48,6 @@ extern const char echo_off_str[];
 extern const char echo_on_str[];
 extern const char go_ahead_str[];
 
-/* OS-dependent declarations. */
-#if defined(_AIX)
-    #include <sys/select.h>
-    int accept args ((int s, struct sockaddr * addr, int *addrlen));
-    int bind args ((int s, struct sockaddr * name, int namelen));
-    void bzero args ((char *b, int length));
-    int getpeername args ((int s, struct sockaddr * name, int *namelen));
-    int getsockname args ((int s, struct sockaddr * name, int *namelen));
-    int gettimeofday args ((struct timeval * tp, struct timezone * tzp));
-    int listen args ((int s, int backlog));
-    int setsockopt args ((int s, int level, int optname, void *optval,
-                          int optlen));
-    int socket args ((int domain, int type, int protocol));
-#endif
-
-#if defined(apollo)
-    #include <unistd.h>
-    void bzero args ((char *b, int length));
-#endif
-
-#if defined(__hpux)
-    int accept args ((int s, void *addr, int *addrlen));
-    int bind args ((int s, const void *addr, int addrlen));
-    void bzero args ((char *b, int length));
-    int getpeername args ((int s, void *addr, int *addrlen));
-    int getsockname args ((int s, void *name, int *addrlen));
-    int gettimeofday args ((struct timeval * tp, struct timezone * tzp));
-    int listen args ((int s, int backlog));
-    int setsockopt args ((int s, int level, int optname,
-                          const void *optval, int optlen));
-    int socket args ((int domain, int type, int protocol));
-#endif
-
 #if defined(interactive)
     #include <net/errno.h>
     #include <sys/fnctl.h>
@@ -98,124 +65,12 @@ extern const char go_ahead_str[];
 */
 
     int close args ((int fd));
-    int gettimeofday args ((struct timeval * tp, struct timezone * tzp));
+    // int gettimeofday args ((struct timeval * tp, struct timezone * tzp));
     /* int read args( ( int fd, char *buf, int nbyte ) ); */
     int select args ((int width, fd_set * readfds, fd_set * writefds,
                       fd_set * exceptfds, struct timeval * timeout));
     int socket args ((int domain, int type, int protocol));
     /* int write args( ( int fd, char *buf, int nbyte ) ); *//* read,write in unistd.h */
-#endif
-
-#if defined(macintosh)
-    #include <console.h>
-    #include <fcntl.h>
-    #include <unix.h>
-    struct timeval {
-        time_t tv_sec;
-        time_t tv_usec;
-    };
-    #if !defined(isascii)
-        #define isascii(c) ( (c) < 0200 )
-    #endif
-
-    int gettimeofday (struct timeval *tp, void *tzp) {
-        tp->tv_sec = time (NULL);
-        tp->tv_usec = 0;
-    }
-#endif
-
-#if defined(MIPS_OS)
-    extern int errno;
-#endif
-
-#if defined(MSDOS)
-    int gettimeofday args ((struct timeval * tp, void *tzp));
-    int kbhit args ((void));
-#endif
-
-#if defined(NeXT)
-    int close args ((int fd));
-    int fcntl args ((int fd, int cmd, int arg));
-    #if !defined(htons)
-        u_short htons args ((u_short hostshort));
-    #endif
-    #if !defined(ntohl)
-        u_long ntohl args ((u_long hostlong));
-    #endif
-    int read args ((int fd, char *buf, int nbyte));
-    int select args ((int width, fd_set * readfds, fd_set * writefds,
-                      fd_set * exceptfds, struct timeval * timeout));
-    int write args ((int fd, char *buf, int nbyte));
-#endif
-
-#if defined(sequent)
-    int accept args ((int s, struct sockaddr * addr, int *addrlen));
-    int bind args ((int s, struct sockaddr * name, int namelen));
-    int close args ((int fd));
-    int fcntl args ((int fd, int cmd, int arg));
-    int getpeername args ((int s, struct sockaddr * name, int *namelen));
-    int getsockname args ((int s, struct sockaddr * name, int *namelen));
-    int gettimeofday args ((struct timeval * tp, struct timezone * tzp));
-    #if !defined(htons)
-        u_short htons args ((u_short hostshort));
-    #endif
-    int listen args ((int s, int backlog));
-    #if !defined(ntohl)
-        u_long ntohl args ((u_long hostlong));
-    #endif
-    int read args ((int fd, char *buf, int nbyte));
-    int select args ((int width, fd_set * readfds, fd_set * writefds,
-                      fd_set * exceptfds, struct timeval * timeout));
-    int setsockopt args ((int s, int level, int optname, caddr_t optval,
-                          int optlen));
-    int socket args ((int domain, int type, int protocol));
-    int write args ((int fd, char *buf, int nbyte));
-#endif
-
-/* This includes Solaris Sys V as well */
-#if defined(sun)
-    int accept args ((int s, struct sockaddr * addr, int *addrlen));
-    int bind args ((int s, struct sockaddr * name, int namelen));
-    void bzero args ((char *b, int length));
-    int close args ((int fd));
-    int getpeername args ((int s, struct sockaddr * name, int *namelen));
-    int getsockname args ((int s, struct sockaddr * name, int *namelen));
-    int listen args ((int s, int backlog));
-    int read args ((int fd, char *buf, int nbyte));
-    int select args ((int width, fd_set * readfds, fd_set * writefds,
-                      fd_set * exceptfds, struct timeval * timeout));
-
-    #if !defined(__SVR4)
-        int gettimeofday args ((struct timeval * tp, struct timezone * tzp));
-
-        #if defined(SYSV)
-            int setsockopt args ((int s, int level, int optname,
-                                  const char *optval, int optlen));
-        #else
-            int setsockopt args ((int s, int level, int optname, void *optval,
-                                  int optlen));
-        #endif
-    #endif
-    int socket args ((int domain, int type, int protocol));
-    int write args ((int fd, char *buf, int nbyte));
-#endif
-
-#if defined(ultrix)
-    int accept args ((int s, struct sockaddr * addr, int *addrlen));
-    int bind args ((int s, struct sockaddr * name, int namelen));
-    void bzero args ((char *b, int length));
-    int close args ((int fd));
-    int getpeername args ((int s, struct sockaddr * name, int *namelen));
-    int getsockname args ((int s, struct sockaddr * name, int *namelen));
-    int gettimeofday args ((struct timeval * tp, struct timezone * tzp));
-    int listen args ((int s, int backlog));
-    int read args ((int fd, char *buf, int nbyte));
-    int select args ((int width, fd_set * readfds, fd_set * writefds,
-                      fd_set * exceptfds, struct timeval * timeout));
-    int setsockopt args ((int s, int level, int optname, void *optval,
-                          int optlen));
-    int socket args ((int domain, int type, int protocol));
-    int write args ((int fd, char *buf, int nbyte));
 #endif
 
 /* Function prototypes. */


### PR DESCRIPTION
A few minor changes to improve the initial build stability so that
it will build in docker with no issues:

  * Removed definitions for systems that we're not building in
  * Updated dockerfile to be ubuntu:focal (20.04 LTS)
  * Updated readme to reflect necessity for docker-compose build
  * Commented out unnecessary gettimeofday reference that was bork